### PR TITLE
docbuild bug fix and speedup

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -22,30 +22,43 @@ import subprocess
 import os
 import sys
 
-cmd = "conda install -y -c conda-forge sphinx numpydoc sphinx_rtd_theme sphinx-automodapi jupyter_sphinx"
-print(f'\n*** Installing pre-requisite packages to build the docs***\n$ {cmd}')
-scmd = shlex.split(cmd)
-result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False)
-stderr = result.stderr
-stdout = result.stdout
-returncode = result.returncode
-print(f'\n****Exited with {returncode}')
-if stdout:
-	print(f'****stdout****\n{stdout.decode()}')
-if stderr:
-	print(f'****stderr****\n{stderr.decode()}')
-print("Pre-requisite installation Complete!")
+# first install prerequisite packages
+try:
+	import sphinx
+	import numpydoc
+	import sphinx_rtd_theme
+	import sphinx_automodapi
+	import jupyter_sphinx
+except ImportError:
+	cmd = "conda install -y -c conda-forge sphinx numpydoc sphinx_rtd_theme sphinx-automodapi jupyter_sphinx"
+	print(f'\n*** Installing pre-requisite packages to build the docs***\n$ {cmd}')
+	scmd = shlex.split(cmd)
+	try:
+		result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False)
+	except FileNotFoundError:
+		# some windows systems appear to require this switch
+		result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False, shell=True)
+	stderr = result.stderr
+	stdout = result.stdout
+	returncode = result.returncode
+	print(f'\n****Exited with {returncode}')
+	if stdout:
+		print(f'****stdout****\n{stdout.decode()}')
+	if stderr:
+		print(f'****stderr****\n{stderr.decode()}')
+	print("Pre-requisite installation Complete!")
 
-
-print(sys.argv)
+# then build the docs
 pwd = os.getcwd()
 import qiskit_metal
 from pathlib import Path
+
 path = Path(qiskit_metal.__file__).parent.parent / 'docs'
 os.chdir(path)
 print(f'\n*** Running the build***\n$ make html')
 
 from sys import platform
+
 if platform == "darwin":
 	scmd = shlex.split("make html")
 	result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False)


### PR DESCRIPTION
Problems solved:
1. build_docs.py causing FileNotFoundError on the conda install for "some" windows users.
2. conda install takes time for every run

Solution:
1. add a try-except, so that if the error occurs, the flag shell=True is added to the launch (note the shell=True is incompatible with mac, but since not mac user has received the FileNotFoundError so far, this solution seems to hold.
2. conda install is skipped now if the import of the packages is successful (other try: except)

### Did you add tests to cover your changes (yes/no)? **No need**
### Did you update the documentation accordingly (yes/no)? **No need**

PR sign-off required test: new conda env that does not have the packages installed (internal try-except), or just uninstall one of the packages from an existing env. Then test again on the same environment (external try-except)