### PR TITLE
Move method to base class so all renderers can use it.

### DIFF
--- a/qiskit_metal/renderers/renderer_base/renderer_base.py
+++ b/qiskit_metal/renderers/renderer_base/renderer_base.py
@@ -19,6 +19,7 @@ import logging
 import inspect
 from copy import deepcopy
 from typing import TYPE_CHECKING
+from typing import List, Tuple, Union, Any, Iterable
 from typing import Dict as Dict_
 from typing import List, Tuple, Union
 
@@ -288,6 +289,14 @@ class QRenderer():
         options = deepcopy(Dict(design.template_options[template_key]))
 
         return options
+
+    def parse_value(self, value: Union[Any, List, Dict, Iterable]) -> Any:
+        """Same as design.parse_value. See design for help.
+
+        Returns:
+            Parsed value of input.
+        """
+        return self.design.parse_value(value)
 
     def update_options(self,
                        render_options: Dict = None,

--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -198,14 +198,6 @@ class QGDSRenderer(QRenderer):
 
         QGDSRenderer.load()
 
-    def parse_value(self, value: Union[Any, List, Dict, Iterable]) -> Any:
-        """Same as design.parse_value. See design for help.
-
-        Returns:
-            Parsed value of input.
-        """
-        return self.design.parse_value(value)
-
     def check_bounding_box_scale(self):
         """
         Some error checking for bounding_box_scale_x and bounding_box_scale_y numbers.
@@ -279,7 +271,8 @@ class QGDSRenderer(QRenderer):
                 subtract_false)
 
     @staticmethod
-    def get_bounds(gs_table: geopandas.GeoSeries) -> Tuple[float, float, float, float]:
+    def get_bounds(
+            gs_table: geopandas.GeoSeries) -> Tuple[float, float, float, float]:
         """Get the bounds for all of the elements in gs_table.
 
         Args:
@@ -414,8 +407,7 @@ class QGDSRenderer(QRenderer):
 
         return unique_qcomponents, 0
 
-    def create_qgeometry_for_gds(self,
-                                 highlight_qcomponents: list = []) -> int:
+    def create_qgeometry_for_gds(self, highlight_qcomponents: list = []) -> int:
         """Using self.design, this method does the following:
 
         1. Gather the QGeometries to be used to write to file.
@@ -788,7 +780,8 @@ class QGDSRenderer(QRenderer):
         midpoints = [
             QGDSRenderer.midpoint_xy(coords[idx - 1][0], coords[idx - 1][1],
                                      vertex2[0], vertex2[1])
-            for idx, vertex2 in enumerate(coords) if idx > 0
+            for idx, vertex2 in enumerate(coords)
+            if idx > 0
         ]
         all_idx_bad_fillet['midpoints'] = midpoints
 
@@ -1196,8 +1189,7 @@ class QGDSRenderer(QRenderer):
         else:
             return 0
 
-    def qgeometry_to_gds(self,
-                         qgeometry_element: pd.Series) -> 'gdspy.polygon':
+    def qgeometry_to_gds(self, qgeometry_element: pd.Series) -> 'gdspy.polygon':
         """Convert the design.qgeometry table to format used by GDS renderer.
         Convert the class to a series of GDSII elements.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes issue #137 

### Did you add tests to cover your changes (yes/no)?
run_all_tests passed
Also, manually created multiple GDS files to ensure the code still works.

### Did you update the documentation accordingly (yes/no)?
There are docstrings in the method that was moved.

### Did you read the CONTRIBUTING document (yes/no)?

### Summary
Move method from child class to parent base class. 


### Details and comments
This move allows the Plug-In developers to use the method from QRenderer base class.
The branch pas_parse_values_to_QDevlopers can be deleted after the merge.

