### PR TITLE
My First Custom QComponent Notebook Delete Functionality Updated

### DIFF
--- a/guide/2 Front End User/2.1 My first custom QComponent/2.1 My First Custom QComponent.ipynb
+++ b/guide/2 Front End User/2.1 My first custom QComponent/2.1 My First Custom QComponent.ipynb
@@ -276,7 +276,7 @@
    "source": [
     "We saw in an earlier example how to delete all QComponents in a design using the either the \"design.delete_all_components\" command or by using the \"Delete all\" button in the GUI. But what if we only want to delete specific QComponents without deleting everything in a design? \n",
     "\n",
-    "We can delete a specific qcomponent using either the GUI or the python API. If you wish to remove a specific QComponent, you can do so using the \"delete_component\" or \"_delete component\" commands. The first takes the string reference to a Qcomponent, while the second takes an integer reference to a QComponent. Suppose we want to remove qubit 'Q1'. We do not need to pass a Boolean corresponding to whether we want to force the delete (true=1) even if the component has dependencies, or whether the deletion should not be executed in the event the QComponent does have dependencies (false=0). The bool option is for future potential possibilities of having Qcomponents with dependencies. "
+    "We can delete a specific qcomponent using either the GUI or the python API. If you wish to remove a specific QComponent, you can do so using the \"delete_component\" or \"_delete component\" commands. The first takes the string reference to a Qcomponent, while the second takes an integer reference to a QComponent. Suppose we want to remove qubit 'Q1'. Presently, we do not need to pass a Boolean corresponding to whether we want to force the delete (true=1) even if the component has dependencies, or whether the deletion should not be executed in the event the QComponent does have dependencies (false=0). The bool option is for future potential possibilities of having Qcomponents with dependencies. "
    ]
   },
   {
@@ -285,7 +285,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "design.delete_component('Q1',1)\n",
+    "design.delete_component('Q1')\n",
     "gui.rebuild()\n",
     "gui.autoscale()"
    ]


### PR DESCRIPTION
The "My First Custom QComponent" notebook was updated with improved documentation on the delete functionality. Specifically, the description and examples were updated to include the two cases of deleting a Qcomponent by passing either a string (QComponent name) or an integer (QComponent ID). This closes Issue #148. This branch can be deleted after merging. 
