### PR TITLE
Fix issue #190.  This has the correct width for buffer for linestring.

### DIFF
--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -1229,7 +1229,7 @@ class QGDSRenderer(QRenderer):
         path_sub_geo = path_sub_df['geometry'].tolist()
         path_sub_width = path_sub_df['width'].tolist()
         for n in range(len(path_sub_geo)):
-            path_sub_geo[n] = path_sub_geo[n].buffer(path_sub_width[n],
+            path_sub_geo[n] = path_sub_geo[n].buffer(path_sub_width[n] / 2,
                                                      cap_style=style_cap,
                                                      join_style=style_join)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Fixes Issue #190.  

### Did you add tests to cover your changes (yes/no)?
No

### Did you update the documentation accordingly (yes/no)?
No

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
The size of the cpw line-string keep-out region is better.


### Details and comments
Tested with GDS output with @ThomasGM4 

