### PR TITLE
Pushed docs title down so it's not covered

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,10 @@ version = qiskit_metal.__version__
 release = qiskit_metal.__version__
 
 rst_prolog = """
+.. raw:: html
+
+    <br><br><br>
+
 .. |version| replace:: {0}
 """.format(release)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,3 @@
-.. raw:: html
-
-    <br><br><br>
-
 ####################################
 Qiskit Metal |version| documentation
 ####################################


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes #314 

### Did you add tests to cover your changes (yes/no)?
No

### Did you update the documentation accordingly (yes/no)?
No

### Did you read the CONTRIBUTING document (yes/no)?
No

### Summary
Pushed docs title down so it's not covered.  Single change that adds a few empty lines so the title bar of the docs theme doesn't cover the title of our pages.

![image](https://user-images.githubusercontent.com/68995878/109157416-fad77000-773f-11eb-9032-6b8e53804fe0.png)
