### PR TITLE
Notebook added for resonator between launch-pad and open-to-ground.

### DIFF
--- a/docs/tut/ResonatorAndLaunchPad.ipynb
+++ b/docs/tut/ResonatorAndLaunchPad.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Resonator between launch-pad and open-to-ground."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Enables module automatic reload. \n",
+    "#Your notebook will be able to pick up code updates made to qiskit-metal (or other) module code.\n",
+    "\n",
+    "%reload_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import key libraries and open the Metal GUI. Also we configure the notebook to enable overwriting of existing components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_metal import designs, draw\n",
+    "from qiskit_metal import MetalGUI, Dict, Headings\n",
+    "\n",
+    "design = designs.DesignPlanar()\n",
+    "gui = MetalGUI(design)\n",
+    "\n",
+    "# If you disable the next line with \"overwrite_enabled\", then you will need to \n",
+    "# delete a component [<component>.delete()] before recreating it.\n",
+    "design.overwrite_enabled = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_metal.qlibrary.passives.launchpad_wb_coupled import LaunchpadWirebondCoupled\n",
+    "\n",
+    "#Explore the options of the LaunchpadWirebondCoupled.\n",
+    "LaunchpadWirebondCoupled.get_template_options(design)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_metal.qlibrary.interconnects.meandered import RouteMeander\n",
+    "\n",
+    "#Explore the options of the RouteMeander.\n",
+    "RouteMeander.get_template_options(design)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from qiskit_metal.qlibrary.connectors.open_to_ground import OpenToGround\n",
+    "\n",
+    "#Explore the options of the OpenToGround.\n",
+    "OpenToGround.get_template_options(design)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Setup the launchpad location and orientation.\n",
+    "launch_options = dict(pos_x='990um', pos_y='2812um', orientation='270', lead_length='30um')\n",
+    "\n",
+    "lp = LaunchpadWirebondCoupled(design, 'P4_Q', options = launch_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Setup the OpenToGround location and orientation.\n",
+    "otg_options = dict(pos_x='2.5mm',  pos_y='0.5mm', orientation='0')\n",
+    "\n",
+    "otg = OpenToGround(design, 'open_to_ground', options=otg_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#After the two QComponents are added to design, connect them with a RouteMeander.\n",
+    "meander_options = Dict(\n",
+    "        total_length='10 mm',\n",
+    "        fillet='90 um',\n",
+    "        lead = dict(start_straight='100um'),\n",
+    "        pin_inputs=Dict(\n",
+    "            start_pin=Dict(component=lp.name, pin='tie'),\n",
+    "            end_pin=Dict(component=otg.name, pin='open')), )\n",
+    "\n",
+    "meander = RouteMeander(design, 'bus',  options=meander_options)\n",
+    "gui.rebuild()\n",
+    "gui.autoscale()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of all the qcomponents in QDesign and then zoom on them.\n",
+    "all_component_names = design.components.keys()\n",
+    "\n",
+    "gui.zoom_on_components(all_component_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the options of the launch pad in QDesign.\n",
+    "lp.options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the options of the RouteMeander in QDesign.\n",
+    "meander.options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Save screenshot as a .png formatted file.\n",
+    "gui.screenshot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Closing the Qiskit Metal GUI\n",
+    "gui.main_window.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
When merge happens, Close Issue #330 and can delete the branch.

### Did you add tests to cover your changes (yes/no)?
Ran the notebook.

### Did you update the documentation accordingly (yes/no)?
Comments in notebook.

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
This places a RouteMeander between a launch-pad and open-to-ground.


### Details and comments
Smile, life is good.  Notebook works.

