### PR TITLE
Fix package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     author_email="qiskit@qiskit.org",
     license="Apache 2.0",
     classifiers=[
-        "Environment :: Console",
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
@@ -44,10 +43,7 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum",
@@ -55,4 +51,9 @@ setup(
     package_data={"": ["*.ui", "*.qrc", "_imgs/*.png", "_imgs/*.txt"]},
     python_requires=">=3.7, <=3.7.8",
     install_requires=requirements,
+    project_urls={
+        "Bug Tracker": "https://github.com/Qiskit/qiskit-metal/issues",
+        "Documentation": "https://qiskit.org/documentation/metal",
+        "Source Code": "https://github.com/Qiskit/qiskit-metal",
+    },
 )


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes serval issues with the package metadata. The first is
the trove classifiers were incorrectly listing the package as supporting
multiple versions of python, however the current metal repo only
supports 3.7 (and a narrow subset too) so the unsupported python
versions are removed. Additionally, it was listing metal as a console
application which it is not, it's a GUI and an API. Then additional
metadata is added to add links to the tracker, documentation, and source
repo.

### Details and comments
