### PR TITLE
Override jinja variables to point navbar directly to Metal Github page

### DIFF
--- a/docs/_templates/theme_variables.jinja
+++ b/docs/_templates/theme_variables.jinja
@@ -1,0 +1,15 @@
+{%- set external_urls = {
+  'github': 'https://github.com/Qiskit/qiskit-metal',
+  'github_issues': 'https://github.com/Qiskit/qiskit-metal/issues',
+  'contributing': 'https://github.com/Qiskit/qiskit/blob/master/CONTRIBUTING.md',
+  'docs': 'https://qiskit.org/documentation/',
+  'twitter': 'https://twitter.com/qiskit',
+  'slack': 'https://qiskit.slack.com',
+  'home': 'https://qiskit.org/',
+  'resources': 'https://qiskit.org/learn',
+  'youtube': 'https://www.youtube.com/qiskit',
+  'iqx': 'https://quantum-computing.ibm.com/',
+  'iqx_systems': 'https://quantum-computing.ibm.com/docs/manage/backends/',
+  'ibm': 'https://www.ibm.com/quantum-computing/',
+}
+-%}


### PR DESCRIPTION
Does what the title says.
