### PR TITLE
Included the length of the hanging cpw of the cpw_hanger_t as an option

### DIFF
--- a/qiskit_metal/qlibrary/connectors/cpw_hanger_t.py
+++ b/qiskit_metal/qlibrary/connectors/cpw_hanger_t.py
@@ -43,6 +43,7 @@ class CPWHangerT(QComponent):
         * coupling_space: '3um' -- The amount of ground plane between the two transmission lines
         * coupling_length: '100um' -- The length of parallel between the two transmission lines
           note: this includes the distance of the curved second of the second line
+        * down_length: '100um' -- The length of the hanging part of the resonator, including the curved region
         * fillet: '25um'
         * pos_x: '0um' -- The x position of the ground termination.
         * pos_y: '0um' -- The y position of the ground termination.
@@ -65,6 +66,7 @@ class CPWHangerT(QComponent):
                            second_gap='6um',
                            coupling_space='3um',
                            coupling_length='100um',
+                           down_length='100um',
                            fillet='25um',
                            pos_x='0um',
                            pos_y='0um',
@@ -89,7 +91,7 @@ class CPWHangerT(QComponent):
                                      [prime_cpw_length / 2, 0]])
 
         #Secondary CPW
-        second_down_length = p.coupling_length * 2
+        second_down_length = p.down_length
         second_y = -p.prime_width / 2 - p.prime_gap - p.coupling_space - p.second_gap - p.second_width / 2
         second_cpw = draw.LineString(
             [[second_flip * (-p.coupling_length / 2), second_y],

--- a/qiskit_metal/tests/test_components_2_options.py
+++ b/qiskit_metal/tests/test_components_2_options.py
@@ -491,6 +491,7 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         self.assertEqual(options['second_gap'], '6um')
         self.assertEqual(options['coupling_space'], '3um')
         self.assertEqual(options['coupling_length'], '100um')
+        self.assertEqual(options['down_length'], '100um')
         self.assertEqual(options['fillet'], '25um')
         self.assertEqual(options['pos_x'], '0um')
         self.assertEqual(options['pos_y'], '0um')

--- a/qiskit_metal/tests/test_components_2_options.py
+++ b/qiskit_metal/tests/test_components_2_options.py
@@ -484,7 +484,7 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         options = hanger_t.default_options
 
         # Test all elements of the result data against expected data
-        self.assertEqual(len(options), 14)
+        self.assertEqual(len(options), 15)
         self.assertEqual(options['prime_width'], '10um')
         self.assertEqual(options['prime_gap'], '6um')
         self.assertEqual(options['second_width'], '10um')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
The enhancement issue #445 (also from me)

### Did you add tests to cover your changes (yes/no)?
yes (modified the test_components_2_options file)

### Did you update the documentation accordingly (yes/no)?
no (I did not find the location where the new option would be included)

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
This is a minimal change to improve the customizability of cpw_hanger_t elements on chips and set them to a specific value instead of two times the coupling length. This should give people more freedom in their chip design.


### Details and comments


