### PR TITLE
edit setup(), passing freq to Ansys

### DIFF
--- a/qiskit_metal/renderers/renderer_ansys/hfss_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/hfss_renderer.py
@@ -747,7 +747,7 @@ class QHFSSRenderer(QAnsysRenderer):
                                         'The value for min_freq_ghz should be an int. '
                                         f'The present value is {value}.')
                                 else:
-                                    self.pinfo.setup.min_freq_ghz = value
+                                    self.pinfo.setup.min_freq = f'{value}GHz'
                                     continue
                             if key == 'max_delta_f':
                                 if not isinstance(value, float):
@@ -848,7 +848,7 @@ class QHFSSRenderer(QAnsysRenderer):
                                         'The value for freq_ghz should be an int. '
                                         f'The present value is {value}.')
                                 else:
-                                    self.pinfo.setup.freq_ghz = value
+                                    self.pinfo.setup.solution_freq = f'{value}GHz'
                                     continue
                             if key == 'max_passes':
                                 if not isinstance(value, int):

--- a/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -345,8 +345,9 @@ class QQ3DRenderer(QAnsysRenderer):
                             if key == "freq_ghz":
                                 if not isinstance(value, float):
                                     self.logger.warning(
-                                        'The value for min_freq_ghz should be an int. '
-                                        f'The present value is {value}.')
+                                        'The value for min_freq_ghz should be a '
+                                        f'float.  The present value is {value}.'
+                                    )
                                 else:
                                     ### This EditSetup works if we change all of the arguments
                                     # at the same time.  We don't always want to change all of them.
@@ -369,7 +370,7 @@ class QQ3DRenderer(QAnsysRenderer):
                                     # ]
                                     # self.pinfo.design._setup_module.EditSetup(
                                     #     setup_args.name, args_editsetup)
-                                    self.pinfo.setup.frequency = value
+                                    self.pinfo.setup.frequency = f"{value}GHz"
                                     continue
                             if key == 'max_passes':
                                 if not isinstance(value, int):


### PR DESCRIPTION
…  Fix for eigenmode and drivenmodal also.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
When using pinfo.setup property variables.  The format for frequency is different than other property variables.
This fix addresses the difference for frequency for q3d, eigenmode and driven modal.

### Did you add tests to cover your changes (yes/no)?
Ran run all tests.

### Did you update the documentation accordingly (yes/no)?
no, the doc strings were accurate.

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
Tested the code manually for all three design types.


### Details and comments
When merged, closes Issue #464. 

