### PR TITLE
fixed bug preventing metal from starting if docs build interrupted

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -90,19 +90,24 @@ print(f'\n*** Running the build***\n$ make html')
 
 from sys import platform
 
-if platform == "darwin":
-    scmd = shlex.split("make html")
-    result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False)
-    stderr = result.stderr
-    stdout = result.stdout
-    returncode = result.returncode
-    print(f'\n****Exited with {returncode}')
-    if stdout:
-        print(f'****stdout****\n{stdout.decode()}')
-    if stderr:
-        print(f'****stderr****\n{stderr.decode()}')
-else:
-    os.system("make html")
+try:
+    if platform == "darwin":
+        scmd = shlex.split("make html")
+        result = subprocess.run(scmd, stdout=subprocess.PIPE, check=False)
+        stderr = result.stderr
+        stdout = result.stdout
+        returncode = result.returncode
+        print(f'\n****Exited with {returncode}')
+        if stdout:
+            print(f'****stdout****\n{stdout.decode()}')
+        if stderr:
+            print(f'****stderr****\n{stderr.decode()}')
+    else:
+        os.system("make html")
+except KeyboardInterrupt:
+    print("\nTerminating... please wait")
+    os.remove('.buildingdocs')
+    exit(1)
 
 os.chdir(pwd)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes #134 

### Did you add tests to cover your changes (yes/no)?
Not needed

### Did you update the documentation accordingly (yes/no)?
Not needed

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
Fixed the bug that prevented metal from starting in the event that the docs build was interrupted by simply catching the keyboard interrupted and terminating gracefully.


