### PR TITLE
509

### DIFF
--- a/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
@@ -374,8 +374,8 @@ class QAnsysRenderer(QRenderer):
               Defaults to None.
             UserSpecifyFolder (int, optional): 0 if default folder for plot is used, 1 otherwise.
               Defaults to None.
-            QuantityName (str, optional): Type of plot to create. Possible values are 
-              Mesh plots - "Mesh"; 
+            QuantityName (str, optional): Type of plot to create. Possible values are
+              Mesh plots - "Mesh";
               Field plots - "Mag_E", "Mag_H", "Mag_Jvol", "Mag_Jsurf","ComplexMag_E",
               "ComplexMag_H", "ComplexMag_Jvol", "ComplexMag_Jsurf", "Vector_E", "Vector_H",
               "Vector_Jvol", "Vector_Jsurf", "Vector_RealPoynting","Local_SAR", "Average_SAR".
@@ -878,14 +878,31 @@ class QAnsysRenderer(QRenderer):
         if self.case == 2:  # One or more components not in QDesign.
             self.logger.warning('One or more components not found.')
             return []
-        elif self.case == 1:  # All components rendered.
+        chip_names = set()
+        if self.case == 1:  # All components rendered.
             comps = self.design.components
-            return list(set(comps[qcomp].options.chip for qcomp in comps))
+            for qcomp in comps:
+                if 'chip' not in comps[qcomp].options:
+                    self.chip_designation_error()
+                    return []
+                chip_names.add(comps[qcomp].options.chip)
         else:  # Strict subset rendered.
             icomps = self.design._components
-            return list(
-                set(icomps[qcomp_id].options.chip
-                    for qcomp_id in self.qcomp_ids))
+            for qcomp_id in self.qcomp_ids:
+                if 'chip' not in icomps[qcomp_id].options:
+                    self.chip_designation_error()
+                    return []
+                chip_names.add(icomps[qcomp_id].options.chip)
+        return list(chip_names)
+
+    def chip_designation_error(self):
+        """
+        Warning message that appears when the Ansys renderer fails to locate a component's chip designation.
+        Provides instructions for a temporary workaround until the layer stack is finalized.
+        """
+        self.logger.warning(
+            "This component currently lacks a chip designation. Please add chip='main' to the component's default_options dictionary, restart the kernel, and try again."
+        )
 
     def get_min_bounding_box(self) -> Tuple[float]:
         """

--- a/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
@@ -885,12 +885,18 @@ class QAnsysRenderer(QRenderer):
                 if 'chip' not in comps[qcomp].options:
                     self.chip_designation_error()
                     return []
+                elif comps[qcomp].options.chip != 'main':
+                    self.chip_not_main()
+                    return []
                 chip_names.add(comps[qcomp].options.chip)
         else:  # Strict subset rendered.
             icomps = self.design._components
             for qcomp_id in self.qcomp_ids:
                 if 'chip' not in icomps[qcomp_id].options:
                     self.chip_designation_error()
+                    return []
+                elif icomps[qcomp_id].options.chip != 'main':
+                    self.chip_not_main()
                     return []
                 chip_names.add(icomps[qcomp_id].options.chip)
         return list(chip_names)
@@ -902,6 +908,16 @@ class QAnsysRenderer(QRenderer):
         """
         self.logger.warning(
             "This component currently lacks a chip designation. Please add chip='main' to the component's default_options dictionary, restart the kernel, and try again."
+        )
+
+    def chip_not_main(self):
+        """
+        Warning message that appears when a component's chip designation is not 'main'.
+        As of 05/10/21, all chip designations should be 'main' until the layer stack is finalized.
+        Provides instructions for a temporary workaround until the layer stack is finalized.
+        """
+        self.logger.warning(
+            "The chip designation for this component is not 'main'. Please set chip='main' in its default_options dictionary, restart the kernel, and try again."
         )
 
     def get_min_bounding_box(self) -> Tuple[float]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
509

### Did you add tests to cover your changes (yes/no)?
No

### Did you update the documentation accordingly (yes/no)?
Yes

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
This PR closes issue 509. It adds a temporary warning message telling users what to do if they are unable to render a component because its default options dictionary does not contain chip='main'.


### Details and comments


