### PR TITLE
Run LOM analysis with pre-saved cap matrix data (Partially resolve #507)

### DIFF
--- a/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -622,7 +622,8 @@ def lumped_oscillator_from_path(path: str, Lj_nH: float, Cj_fF: float, N: int,
                                 fr: Union[list, float],
                                 fb: Union[list, float]) -> pd.DataFrame:
     """Obtain a single result dataframe from a Q3D capacitance file pointed to by path.
-    Similar to lumped_oscillator_vs_passes() but for a user provided capacitance matrix file.
+    Similar to member method lumped_oscillator_vs_passes() of QQ3DRenderer but for a user
+    provided capacitance matrix file.
 
     Args:
         path (str): Path to file.
@@ -652,7 +653,10 @@ def lumped_oscillator_from_path(path: str, Lj_nH: float, Cj_fF: float, N: int,
                                                N,
                                                fb,
                                                fr,
-                                               g_scale=1)
+                                               g_scale=1,
+                                               print_info=True)
+
+    RES = pd.DataFrame([RES])
     RES['χr MHz'] = abs(RES['chi_in_MHz'].apply(lambda x: x[0]))
     RES['gr MHz'] = abs(RES['gbus'].apply(lambda x: x[0]))
     return RES

--- a/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -25,6 +25,7 @@ from pyEPR.calcs.convert import Convert
 from qiskit_metal import Dict
 from qiskit_metal.renderers.renderer_ansys.ansys_renderer import QAnsysRenderer
 from qiskit_metal.toolbox_metal.parsing import is_true
+from qiskit_metal.analyses.quantization.lumped_capacitive import load_q3d_capacitance_matrix
 
 from .. import config
 if not config.is_building_docs():
@@ -531,6 +532,52 @@ class QQ3DRenderer(QAnsysRenderer):
                 print_info=bool(i == maxPass - 1))
             RES[i] = res
         RES = pd.DataFrame(RES).transpose()
+        RES['χr MHz'] = abs(RES['chi_in_MHz'].apply(lambda x: x[0]))
+        RES['gr MHz'] = abs(RES['gbus'].apply(lambda x: x[0]))
+        return RES
+
+    def lumped_oscillator_from_path(self,
+                                    path: str,
+                                    Lj_nH: float,
+                                    Cj_fF: float,
+                                    N: int,
+                                    fr: Union[list, float],
+                                    fb: Union[list, float],
+                                    maxPass: int,
+                                    variation: str = '',
+                                    g_scale: float = 1) -> dict:
+        """Obtain a single result dataframe from a Q3D capacitance file pointed to by path.
+        Similar to lumped_oscillator_vs_passes() but for a user provided capacitance matrix file.
+
+        Args:
+            path (str): Path to file.
+            Lj_nH (float): Junction inductance (in nH)
+            Cj_fF (float): Junction capacitance (in fF)
+            N (int): Coupling pads (1 readout, N - 1 bus)
+            fr (Union[list, float]):Readout frequencies (in GHz). fr can be a list with the order
+                they appear in the capMatrix.
+            fb (Union[list, float]): Coupling bus frequencies (in GHz). fb can be a list with the order
+                they appear in the capMatrix.
+            g_scale (float, optional): Scale factor. Defaults to 1..
+
+        Returns:
+            dict: A single dataframe corresponding to a single capacitance matrix
+        """
+        IC_Amps = Convert.Ic_from_Lj(Lj_nH, 'nH', 'A')
+        CJ = ureg(f'{Cj_fF} fF').to('farad').magnitude
+        fr = ureg(f'{fr} GHz').to('GHz').magnitude
+        fb = [ureg(f'{freq} GHz').to('GHz').magnitude for freq in fb]
+
+        df_cmat, user_units, _, _, = load_q3d_capacitance_matrix(path)
+        c_units = ureg(user_units).to('farads').magnitude
+
+        RES = extract_transmon_coupled_Noscillator(df_cmat.values * c_units,
+                                                   IC_Amps,
+                                                   CJ,
+                                                   N,
+                                                   fb,
+                                                   fr,
+                                                   g_scale=1)
         RES['χr MHz'] = abs(RES['chi_in_MHz'].apply(lambda x: x[0]))
         RES['gr MHz'] = abs(RES['gbus'].apply(lambda x: x[0]))
         return RES


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
https://github.com/Qiskit/qiskit-metal/issues/507

### Did you add tests to cover your changes (yes/no)?
Tested newly added function in a notebook

### Did you update the documentation accordingly (yes/no)?
yes

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
Add the capability to run analysis LOM analysis with pre-saved data (capacitance matrix).

### Details and comments
Added a function that's similar to existing lumped_oscillator_vs_passes() but instead takes a path for a user provided Q3D generated capacitance matrix file and output an one-row dataframe that gives the analysis result. 



