### PR TITLE
matching background color of widget to highlight color of pygments

### DIFF
--- a/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
+++ b/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
@@ -251,6 +251,20 @@ class ParameterEntryWindow(QMainWindow):
         text_source.ensureCursorVisible()
         text_source.setDocument(text_doc)
 
+        # set background colour to match that of formatter and text default to black
+        wiget_background_html = '.highlight { background: '
+        newstr = self._html_css_lex[self._html_css_lex.
+                                    index(wiget_background_html) +
+                                    len(wiget_background_html):]
+        bg_color_1 = newstr[:newstr.find(';')]
+        bg_color_2 = newstr[:newstr.find('}')]
+        bg_color = bg_color_2 if len(bg_color_2) < len(
+            bg_color_1) else bg_color_1
+        text_source.setStyleSheet(f"""
+        background-color: {bg_color}; 
+        color: #000000;
+        """)
+
         self.ui.tab_source.layout().addWidget(text_source)
 
     @QComponentParameterEntryExceptionDecorators.entry_exception_pop_up_warning

--- a/qiskit_metal/_gui/widgets/edit_component/component_widget.py
+++ b/qiskit_metal/_gui/widgets/edit_component/component_widget.py
@@ -185,14 +185,8 @@ class ComponentWidget(QTabWidget):
         self.ui.treeView.setHorizontalScrollMode(
             QAbstractItemView.ScrollPerPixel)
 
-        # Source Code
-        # palette = self.ui.textSource.palette()
-        # palette.color(palette.Text).name()
-        # palette.setColor(palette.Text, QColor('#000000'))
-        # palette.setColor(palette.WindowText, QColor('#000000'))
-        # self.ui.textSource.setPalette(palette)
         self.ui.textSource.setStyleSheet("""
-    color: #000000;
+            color: #000000;
             """)
         self.src_doc = create_QTextDocument(self.ui.textSource)
         self._html_css_lex = None  # type: pygments.formatters.html.HtmlFormatter


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
#595 

### Did you add tests to cover your changes (yes/no)?
no
### Did you update the documentation accordingly (yes/no)?
no
### Did you read the CONTRIBUTING document (yes/no)?
no
### Summary
Param Entry Window's Source tab not has a white background instead of white highlights on a black background.

### Details and comments


