### PR TITLE
Component Widget's textSource bg colour is now that of pygment's highlight

### DIFF
--- a/qiskit_metal/_gui/widgets/edit_component/component_widget.py
+++ b/qiskit_metal/_gui/widgets/edit_component/component_widget.py
@@ -335,6 +335,22 @@ class ComponentWidget(QTabWidget):
             text_html = highlight(text, lexer, formatter)
             document.setHtml(text_html)
 
+            # Grab the highlight colour from pygment's HTML and use it as
+            # the background colour for the textSource widget
+            # Also set the text colour to black
+            wiget_background_html = '.highlight { background: '
+            newstr = self._html_css_lex[self._html_css_lex.
+                                        index(wiget_background_html) +
+                                        len(wiget_background_html):]
+            bg_color_1 = newstr[:newstr.find(';')]
+            bg_color_2 = newstr[:newstr.find('}')]
+            bg_color = bg_color_2 if len(bg_color_2) < len(
+                bg_color_1) else bg_color_1
+            self.ui.textSource.setStyleSheet(f"""
+            background-color: {bg_color}; 
+            color: #000000;
+            """)
+
         else:
             document.setPlainText(text)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
#603 

### Did you add tests to cover your changes (yes/no)?
no
### Did you update the documentation accordingly (yes/no)?
no
### Did you read the CONTRIBUTING document (yes/no)?
no
### Summary
Background is now consistent:

<img width="702" alt="Screen Shot 2021-06-19 at 4 28 48 PM" src="https://user-images.githubusercontent.com/74260313/122655850-6db78d00-d11b-11eb-94a3-74ee7feb52a2.png">

### Details and comments
