### PR TITLE
Update mpl_renderer.py

### DIFF
--- a/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
+++ b/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
@@ -199,6 +199,11 @@ class QMplRenderer():
             'base': dict(linewidth=1, alpha=0.5, edgecolors='k'),
             'subtracted': dict(linestyle='--', color='gray'),
             'non-subtracted': dict()
+        },
+        'JJ': {
+            'base': dict(linewidth=1, alpha=0.2, edgecolors='k'),
+            'subtracted': dict(linestyle='--', color='gray'),
+            'non-subtracted': dict()
         }
     }
     """Styles"""
@@ -279,9 +284,7 @@ class QMplRenderer():
                                           resolution=int(self.options[
                                               'resolution'])),
                     axis=1)
-                kw = self.get_style('poly',
-                                    subtracted=subtracted,
-                                    extra=extra_kw)
+                kw = self.get_style('JJ', subtracted=subtracted, extra=extra_kw)
                 self.render_poly(table1, ax, subtracted=subtracted, extra_kw=kw)
             table1 = table[mask]
             if len(table1) > 0:


### PR DESCRIPTION
updated to draw Josephson Junctions a lighter shade when rendered

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

I checked that tutorial notebooks run as expected and that Josephson Junctions are indeed drawn a lighter shade of blue when rendered.  No additional tests included. 

✅ I have updated the documentation accordingly.

No updates to documentation required. 

✅ I have read the CONTRIBUTING document.

Yes
-->


### What are the issues this pull addresses (issue numbers / links)?

This PR addresses issue #617 by drawing JJs a lighter color than the other metal shapes being rendered. This branch can be deleted upon successful merge. 

### Did you add tests to cover your changes (yes/no)?

No tests added, but checked the demo notebooks with transmon pockets run as expected. 

### Did you update the documentation accordingly (yes/no)?

No

### Did you read the CONTRIBUTING document (yes/no)?

Yes

### Summary

Added an extra key in the dictionary for styles so that a Josephson Junction can be rendered with a lighter shading than other polygons / lines being rendered. 

### Details and comments

Same as above. 


