### PR TITLE
Updates to interdigitated and concentric transmon qcomponents

### DIFF
--- a/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
+++ b/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
@@ -73,12 +73,14 @@ class TransmonInterdigitated(QComponent):
         * rotation: '0.0' -- the angle at which the entire structure is rotated
         * rotation_top_pad: '180' -- internal coordinate defining the angle of rotation
           between top and bottom pads
+        * inductor_width: '20.0um' -- the width of the Josephson Junction
         * layer: '1' -- all objects are drawn assuming they are part of the same layer on a
           the chip
     """
 
     # Default drawing options
-    default_options = Dict(pad_width='1000um',
+    default_options = Dict(chip="main",
+                           pad_width='1000um',
                            pad_height='300um',
                            finger_width='50um',
                            finger_height='100um',
@@ -102,6 +104,7 @@ class TransmonInterdigitated(QComponent):
                            position_y='0um',
                            rotation='0.0',
                            rotation_top_pad='180',
+                           inductor_width='20um',
                            layer='1')
     """Default drawing options"""
 
@@ -123,10 +126,11 @@ class TransmonInterdigitated(QComponent):
             p.finger_width, p.finger_height, p.pad_pos_x, p.pad_pos_y +
             0.49999 * (p.pad_height) + 0.49999 * (p.finger_height))
 
-        # draw the Josephson Junction
-        rect_jj = draw.rectangle(
-            p.jj_width, p.finger_space, p.pad_pos_x,
-            0.5 * (p.pad_height) + p.finger_height + 0.5 * (p.finger_space))
+        # draw the Josephson Junction as a LineString
+        rect_jj = draw.LineString([
+            (0, 0.5 * p.pad_height + p.finger_height),
+            (0, 0.5 * p.pad_height + p.finger_height + p.finger_space)
+        ])
 
         # draw the first comb to the right of the lower finger as a rectangle
         comb1_lower = draw.rectangle(
@@ -179,9 +183,9 @@ class TransmonInterdigitated(QComponent):
         top = draw.translate(bottom, 0.0, p.pad_height + p.finger_space)
         top = draw.rotate(top, p.rotation_top_pad)
 
-        # merge everything into a single design
-        design = draw.union(bottom, top, rect_jj, coupling_capacitor,
-                            cc_topleft, cc_topright)
+        # merge everything into a single design (except the JJ!)
+        design = draw.union(bottom, top, coupling_capacitor, cc_topleft,
+                            cc_topright)
 
         # draw the transmon pocket bounding box
         pocket = draw.rectangle(1.5 * p.pad_width, 5.0 * p.pad_height)
@@ -192,17 +196,30 @@ class TransmonInterdigitated(QComponent):
             design, 0.0,
             -0.5 * p.pad_height - p.finger_height - 0.5 * p.finger_space)
 
+        rect_jj = draw.translate(
+            rect_jj, 0.0,
+            -0.5 * p.pad_height - p.finger_height - 0.5 * p.finger_space)
+
         # now translate the final structure according to the user input
         design = draw.rotate(design, p.rotation, origin=(0, 0))
         design = draw.translate(design, p.position_x, p.position_y)
+
+        rect_jj = draw.rotate(rect_jj, p.rotation, origin=(0, 0))
+        rect_jj = draw.translate(rect_jj, p.position_x, p.position_y)
 
         pocket = draw.rotate(pocket, p.rotation, origin=(0, 0))
         pocket = draw.translate(pocket, p.position_x, p.position_y)
 
         geom = {'design': design}
         geom_pocket = {'pocket': pocket}
+        geom_jj = {'design': rect_jj}
         self.add_qgeometry('poly', geom, layer=p.layer, subtract=False)
         self.add_qgeometry('poly', geom_pocket, layer=p.layer, subtract=True)
+        self.add_qgeometry('junction',
+                           geom_jj,
+                           layer=p.layer,
+                           subtract=False,
+                           width=p.inductor_width)
 
         ###################################################################
 

--- a/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
+++ b/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
@@ -11,8 +11,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+"""Interdigitated Transmon.
+"""
 
-#from math import *
 from math import sin, cos
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core.base import QComponent

--- a/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -36,9 +36,9 @@ class TransmonConcentric(BaseQubit):
         * pos_x: '0um'
         * pos_y: '0um'
         * connection_pads: empty Dict -- the dictionary which contains all active
-        connection lines for the qubit.
+          connection lines for the qubit.
         * _default_connection_pads: empty Dict -- the default values for the
-        (if any) connection lines of the qubit.
+          (if any) connection lines of the qubit.
 
     Default Options:
         * width: '1000um' -- Width of transmon pocket
@@ -50,12 +50,12 @@ class TransmonConcentric(BaseQubit):
         * jj_w: '10um' -- Josephson Junction width
         * res_s: '100um' -- Space between top electrode and readout resonator
         * res_ext: '100um' -- Extension of readout resonator in x-direction
-        beyond midpoint of transmon
+          beyond midpoint of transmon
         * fbl_rad: '100um' -- Radius of the flux bias line loop
         * fbl_sp: '100um' -- Spacing between metal pad and flux bias loop
         * fbl_gap: '80um' -- Space between parallel lines of the flux bias loop
         * fbl_ext: '300um' -- Run length of flux bias line between circular
-        loop and edge of pocket
+          loop and edge of pocket
         * pocket_w: '1500um' -- Transmon pocket width
         * pocket_h: '1000um' -- Transmon pocket height
         * position_x: '2.0mm' -- Translate component to be centered on this x-coordinate

--- a/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -11,11 +11,14 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+"""Concentric Transmon.
+"""
 
 from math import sin, cos
 import numpy as np
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core import BaseQubit
+
 
 class TransmonConcentric(BaseQubit):
     """The base `TrasmonConcentric` class .

--- a/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -17,7 +17,6 @@ import numpy as np
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core import BaseQubit
 
-
 class TransmonConcentric(BaseQubit):
     """The base `TrasmonConcentric` class .
 

--- a/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -12,8 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+from math import sin, cos
 import numpy as np
-from math import *
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core import BaseQubit
 
@@ -33,8 +33,10 @@ class TransmonConcentric(BaseQubit):
     BaseQubit Default Options:
         * pos_x: '0um'
         * pos_y: '0um'
-        * connection_pads: empty Dict -- the dictionary which contains all active connection lines for the qubit.
-        * _default_connection_pads: empty Dict -- the default values for the (if any) connection lines of the qubit.
+        * connection_pads: empty Dict -- the dictionary which contains all active
+        connection lines for the qubit.
+        * _default_connection_pads: empty Dict -- the default values for the
+        (if any) connection lines of the qubit.
 
     Default Options:
         * width: '1000um' -- Width of transmon pocket
@@ -45,11 +47,13 @@ class TransmonConcentric(BaseQubit):
         * gap: '35um' -- Radius of gap between two pads
         * jj_w: '10um' -- Josephson Junction width
         * res_s: '100um' -- Space between top electrode and readout resonator
-        * res_ext: '100um' -- Extension of readout resonator in x-direction beyond midpoint of transmon
+        * res_ext: '100um' -- Extension of readout resonator in x-direction
+        beyond midpoint of transmon
         * fbl_rad: '100um' -- Radius of the flux bias line loop
         * fbl_sp: '100um' -- Spacing between metal pad and flux bias loop
         * fbl_gap: '80um' -- Space between parallel lines of the flux bias loop
-        * fbl_ext: '300um' -- Run length of flux bias line between circular loop and edge of pocket
+        * fbl_ext: '300um' -- Run length of flux bias line between circular
+        loop and edge of pocket
         * pocket_w: '1500um' -- Transmon pocket width
         * pocket_h: '1000um' -- Transmon pocket height
         * position_x: '2.0mm' -- Translate component to be centered on this x-coordinate
@@ -60,7 +64,7 @@ class TransmonConcentric(BaseQubit):
 
     # default drawing options
     default_options = Dict(
-        chip="main", 
+        chip="main",
         width='1000um',  # width of transmon pocket
         height='1000um',  # height of transmon pocket
         layer='1',
@@ -100,14 +104,15 @@ class TransmonConcentric(BaseQubit):
         space = draw.Point(0, 0).buffer((p.gap + p.rad_i))
         outer_pad = draw.subtract(outer_pad, space)
         inner_pad = draw.Point(0, 0).buffer(p.rad_i)
-        gap = draw.subtract(space, inner_pad)
-        pads = draw.union(outer_pad, inner_pad)
+        #gap = draw.subtract(space, inner_pad)
+        #pads = draw.union(outer_pad, inner_pad)
 
         # draw the top Josephson Junction
         jj_t = draw.LineString([(0.0, p.rad_i), (0.0, p.rad_i + p.gap)])
 
         # draw the bottom Josephson Junction
-        jj_b = draw.LineString([(0.0, -1.0*p.rad_i), (0.0, -1.0*p.rad_i -1.0*p.gap)])
+        jj_b = draw.LineString([(0.0, -1.0 * p.rad_i),
+                                (0.0, -1.0 * p.rad_i - 1.0 * p.gap)])
 
         # draw the readout resonator
         qp1a = (-0.5 * p.pocket_w, p.rad_o + p.res_s
@@ -158,7 +163,7 @@ class TransmonConcentric(BaseQubit):
         h = qpin_rotate_translate(h)
         i = qpin_rotate_translate(i)
 
-        ################################################################################################
+        ##############################################################
 
         # Use the geometry to create Metal QGeometry
         geom_rr = {'path1': rr}
@@ -181,11 +186,19 @@ class TransmonConcentric(BaseQubit):
                            width=p.cpw_width)
         self.add_qgeometry('poly', geom_outer, layer=1, subtract=False)
         self.add_qgeometry('poly', geom_inner, layer=1, subtract=False)
-        self.add_qgeometry('junction', geom_jjt, layer=1, subtract=False, width=p.inductor_width)
-        self.add_qgeometry('junction', geom_jjb, layer=1, subtract=False, width=p.inductor_width)
+        self.add_qgeometry('junction',
+                           geom_jjt,
+                           layer=1,
+                           subtract=False,
+                           width=p.inductor_width)
+        self.add_qgeometry('junction',
+                           geom_jjb,
+                           layer=1,
+                           subtract=False,
+                           width=p.inductor_width)
         self.add_qgeometry('poly', geom_pocket, layer=1, subtract=True)
 
-        ##################################################################################################
+        ###########################################################################
 
         # Add Qpin connections
         self.add_pin('pin1',

--- a/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -60,6 +60,7 @@ class TransmonConcentric(BaseQubit):
 
     # default drawing options
     default_options = Dict(
+        chip="main", 
         width='1000um',  # width of transmon pocket
         height='1000um',  # height of transmon pocket
         layer='1',
@@ -82,7 +83,8 @@ class TransmonConcentric(BaseQubit):
         position_y=
         '2.0mm',  # translate component to be centered on this y-coordinate
         rotation='0.0',  # degrees to rotate the component by
-        cpw_width='10.0um'  # width of the readout resonator and flux bias line
+        cpw_width='10.0um',  # width of the readout resonator and flux bias line
+        inductor_width='5.0um'  # width of the Josephson Junctions
     )
     """Default drawing options"""
 
@@ -102,14 +104,10 @@ class TransmonConcentric(BaseQubit):
         pads = draw.union(outer_pad, inner_pad)
 
         # draw the top Josephson Junction
-        jj_port_top = draw.rectangle(p.jj_w, p.gap)
-        jj_t = jj_port_top
-        jj_t = draw.translate(jj_t, xoff=0.0, yoff=(p.rad_i + 0.5 * p.gap))
+        jj_t = draw.LineString([(0.0, p.rad_i), (0.0, p.rad_i + p.gap)])
 
         # draw the bottom Josephson Junction
-        jj_port_bottom = draw.rectangle(p.jj_w, p.gap)
-        jj_b = jj_port_bottom
-        jj_b = draw.translate(jj_b, xoff=0.0, yoff=(-(p.rad_i + 0.5 * p.gap)))
+        jj_b = draw.LineString([(0.0, -1.0*p.rad_i), (0.0, -1.0*p.rad_i -1.0*p.gap)])
 
         # draw the readout resonator
         qp1a = (-0.5 * p.pocket_w, p.rad_o + p.res_s
@@ -183,8 +181,8 @@ class TransmonConcentric(BaseQubit):
                            width=p.cpw_width)
         self.add_qgeometry('poly', geom_outer, layer=1, subtract=False)
         self.add_qgeometry('poly', geom_inner, layer=1, subtract=False)
-        self.add_qgeometry('poly', geom_jjt, layer=1, subtract=False)
-        self.add_qgeometry('poly', geom_jjb, layer=1, subtract=False)
+        self.add_qgeometry('junction', geom_jjt, layer=1, subtract=False, width=p.inductor_width)
+        self.add_qgeometry('junction', geom_jjb, layer=1, subtract=False, width=p.inductor_width)
         self.add_qgeometry('poly', geom_pocket, layer=1, subtract=True)
 
         ##################################################################################################

--- a/qiskit_metal/tests/test_qlibrary_2_options.py
+++ b/qiskit_metal/tests/test_qlibrary_2_options.py
@@ -331,7 +331,8 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
             design, 'my_name')
         options = my_transmon_concentric.default_options
 
-        self.assertEqual(len(options), 19)
+        self.assertEqual(len(options), 21)
+        self.assertEqual(options['chip'], 'main')
         self.assertEqual(options['width'], '1000um')
         self.assertEqual(options['height'], '1000um')
         self.assertEqual(options['layer'], '1')
@@ -351,6 +352,7 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         self.assertEqual(options['position_y'], '2.0mm')
         self.assertEqual(options['rotation'], '0.0')
         self.assertEqual(options['cpw_width'], '10.0um')
+        self.assertEqual(options['inductor_width'], '5.0um')
 
     def test_qlibrary_transmon_cross_fl_options(self):
         """Test that default_options of transmon_cross_fl were not accidentally changed."""


### PR DESCRIPTION
Add JJs to qgeometry as junctions rather than polys.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

There already exists a tutorial notebook for the interdigitated transmon. I checked that this notebook still works correctly (and renders the objects appropriately) with the modifications made to the qcomponent. I've also manually tested that the concentric transmon qcomponent still renders correctly. 

✅ I have updated the documentation accordingly.

Documentation already exists for these qcomponents. This is just an update so that the Josephson Junctions render correctly. 

✅ I have read the CONTRIBUTING document.

yes 
-->


### What are the issues this pull addresses (issue numbers / links)?

This PR addresses issue #639. This branch can be deleted upon successful merge. 

### Did you add tests to cover your changes (yes/no)?

There is already a tutorial notebook to test that the interdigitated transmon is drawn correctly. I've tested that this notebook still works as expected. I've also run a manual test to check that the concentric transmon is drawn correctly. 

### Did you update the documentation accordingly (yes/no)?

I've updated comments in the qcomponent files, but otherwise the documentation already exists for these qcomponents. 

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Modified two qcomponents (interdigitated transmon and concentric transmon) so that the josephson junctions are rendered as "junctions" rather than "poly". 

### Details and comments

Draw JJs as linestrings rather than shapely objects and add them to the qgeometry as "junctions" rather than "poly"s. In this way, they appear with a lighter color than the other poly objects in the design when rendered. These components now follow the same convention as the "transmon_pocket" qcomponent. 

