### PR TITLE
Add variables to LOM and scattering Qsimulators

### DIFF
--- a/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -56,7 +56,8 @@ class LumpedElementsSim(QSimulation):
                          percent_refinement=30,
                          auto_increase_solution_order=True,
                          solution_order='High',
-                         solver_type='Iterative')
+                         solver_type='Iterative',
+                         vars=Dict())
     """Default setup."""
 
     # supported labels for data generated from the simulation

--- a/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -56,8 +56,7 @@ class LumpedElementsSim(QSimulation):
                          percent_refinement=30,
                          auto_increase_solution_order=True,
                          solution_order='High',
-                         solver_type='Iterative',
-                         vars=Dict())
+                         solver_type='Iterative')
     """Default setup."""
 
     # supported labels for data generated from the simulation
@@ -128,14 +127,12 @@ class LumpedElementsSim(QSimulation):
         if not self.renderer_initialized:
             self._initialize_renderer()
 
-        vars_to_initialize = self.setup.vars
-        renderer_design_name = self._render(
-            name=name,
-            solution_type='capacitive',
-            selection=components,
-            open_pins=open_terminations,
-            box_plus_buffer=box_plus_buffer,
-            vars_to_initialize=vars_to_initialize)
+        renderer_design_name = self._render(name=name,
+                                            solution_type='capacitive',
+                                            selection=components,
+                                            open_pins=open_terminations,
+                                            box_plus_buffer=box_plus_buffer,
+                                            vars_to_initialize=Dict())
 
         self._analyze()
         return renderer_design_name, self.sim_setup_name

--- a/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -127,11 +127,14 @@ class LumpedElementsSim(QSimulation):
         if not self.renderer_initialized:
             self._initialize_renderer()
 
-        renderer_design_name = self._render(name=name,
-                                            solution_type='capacitive',
-                                            selection=components,
-                                            open_pins=open_terminations,
-                                            box_plus_buffer=box_plus_buffer)
+        vars_to_initialize = self.setup.vars
+        renderer_design_name = self._render(
+            name=name,
+            solution_type='capacitive',
+            selection=components,
+            open_pins=open_terminations,
+            box_plus_buffer=box_plus_buffer,
+            vars_to_initialize=vars_to_initialize)
 
         self._analyze()
         return renderer_design_name, self.sim_setup_name

--- a/qiskit_metal/analyses/simulation/scattering_impedance.py
+++ b/qiskit_metal/analyses/simulation/scattering_impedance.py
@@ -171,14 +171,17 @@ class ScatteringImpedanceSim(QSimulation):
         if not self.renderer_initialized:
             self._initialize_renderer()
 
-        renderer_design_name = self._render(name=name,
-                                            solution_type='drivenmodal',
-                                            selection=components,
-                                            open_pins=open_terminations,
-                                            port_list=port_list,
-                                            jj_to_port=jj_to_port,
-                                            ignored_jjs=ignored_jjs,
-                                            box_plus_buffer=box_plus_buffer)
+        vars_to_initialize = self.setup.vars
+        renderer_design_name = self._render(
+            name=name,
+            solution_type='drivenmodal',
+            selection=components,
+            open_pins=open_terminations,
+            port_list=port_list,
+            jj_to_port=jj_to_port,
+            ignored_jjs=ignored_jjs,
+            box_plus_buffer=box_plus_buffer,
+            vars_to_initialize=vars_to_initialize)
 
         self._analyze()
         return renderer_design_name, self.sim_setup_name


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
No corresponding issue - this is a followup bug fix for PR 641, which is already closed.

### Did you add tests to cover your changes (yes/no)?
No

### Did you update the documentation accordingly (yes/no)?
None needed - no change in docstrings

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
PR 641 added vars_to_initialize (which contains variable info for sweeping purposes) in its _render() method, which affects its subclasses EigenmodeSim, LumpedElementsSim, and ScatteringImpedanceSim. Only EigenmodeSim was modified in that PR. This PR adds vars_to_initialize to the latter 2 classes.

### Details and comments
See above.

