### PR TITLE
Get information after simulations from renderer gui

### DIFF
--- a/qiskit_metal/analyses/core/simulation.py
+++ b/qiskit_metal/analyses/core/simulation.py
@@ -90,7 +90,7 @@ class QSimulation(QAnalysis):
                 if not renderer_ref:
                     raise KeyError  #needed because this is a Dict, not a dict
                 if not (renderer_ref.path_name and renderer_ref.class_name):
-                    self.logger.warning(
+                    self.logger.error(
                         f'The renderer={renderer_name} is not properly configured in'
                         ' config.renderers_to_load. Please add the missing information'
                         ' (Tip: needs to have both a path_name and a class_name keys).'

--- a/qiskit_metal/analyses/quantization/lumped_oscillator_model.py
+++ b/qiskit_metal/analyses/quantization/lumped_oscillator_model.py
@@ -142,15 +142,14 @@ class LOManalysis(QAnalysis):
 
         s = self.setup
 
-        if isinstance(self.sim, Dict):
-            if self.sim.capacitance_matrix == {}:
-                self.logger.warning(
-                    'Please initialize the capacitance_matrix before executing this method.'
-                    '`self.sim.capacitance_matrix = pd.DataFrame(...)`')
-                return
-            if self.sim.capacitance_all_passes == {}:
-                self.sim.capacitance_all_passes[
-                    1] = self.sim.capacitance_matrix.values
+        if self.sim.capacitance_matrix == {}:
+            self.logger.warning(
+                'Please initialize the capacitance_matrix before executing this method.'
+                '`self.sim.capacitance_matrix = pd.DataFrame(...)`')
+            return
+        if self.sim.capacitance_all_passes == {}:
+            self.sim.capacitance_all_passes[
+                1] = self.sim.capacitance_matrix.values
 
         ureg = UnitRegistry()
         ic_amps = Convert.Ic_from_Lj(s.junctions.Lj, 'nH', 'A')

--- a/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -73,22 +73,32 @@ class LumpedElementsSim(QSimulation):
         # set design and renderer
         super().__init__(design, renderer_name)
 
-    def _analyze(self) -> str:
+    def _analyze(self):
         """Executes the analysis step of the Run. First it initializes the renderer setup
         to prepare for the capacitance calculation, then it executes it.
-        Finally it recovers the output of the analysis and stores it in self.capacitance_matrix.
+        Finally it calls _get_results_from_renderer to recovers the simulation output.
         """
         # pylint: disable=attribute-defined-outside-init
         self.sim_setup_name = self.renderer.initialize_cap_extract(**self.setup)
-
         self.renderer.analyze_setup(self.sim_setup_name)
+        self._get_results_from_renderer()
 
-        # extract main (latest) capacitance matrix
-        self.capacitance_matrix, self.units = self.renderer.get_capacitance_matrix(
-        )
-        # extract the capacitance matrices for all passes
-        self.capacitance_all_passes, _ = self.renderer.get_capacitance_all_passes(
-        )
+    def _get_results_from_renderer(self):
+        """Recovers the output of the analysis and stores it in self.capacitance_matrix
+        """
+        if self.renderer_initialized:
+            # pylint: disable=attribute-defined-outside-init
+            # extract main (latest) capacitance matrix
+            self.capacitance_matrix, self.units = self.renderer.get_capacitance_matrix(
+            )
+            # extract the capacitance matrices for all passes
+            self.capacitance_all_passes, _ = self.renderer.get_capacitance_all_passes(
+            )
+        else:
+            self.logger.error(
+                "Please initialize renderer before trying to load the simulation results."
+                " Consider using the method self.renderer._initiate_renderer()"
+                " if you did not already connect qiskit-metal to the renderer.")
 
     def run_sim(  # pylint: disable=arguments-differ
             self,

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.01 Capacitance and LOM.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.01 Capacitance and LOM.ipynb
@@ -220,6 +220,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(otional - case-dependent)<br>If the previous cell was interrupted due to license limitations and for any reason you finally manually launched the simulation from the renderer GUI (outside qiskit-metal) you might be able to recover the simulation results by uncommenting and executing the following cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#c1.sim._get_results_from_renderer()\n",
+    "#c1.sim.capacitance_matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The last variables you pass to the `run()` or `sim.run()` methods, will be stored in the `sim.setup` dictionary under the key `run`. You can recall the information passed by either accessing the dictionary directly, or by using the print handle below."
    ]
   },


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?
It was brought up in the #metal slack channel from @bicycle315 that her use-case requires to run simulations remotely, due to license constraints. With this PR we de-embed the "data harvesting" method (`_get_results_from_renderer()`) from the "analysis run" method (`_analyze(self)`), so that the former can be called independently from the latter, thus enabling her to run the simulations from the Ansys GUI and later harvest the results.
@bicycle315 also brought to our attention that when the sim.capacitance_matrix is empty, there is an non-handled error if we try to run the analysis methods. I thus modified the code to make sure the error is handled by showing a descriptive message

### Did you add tests to cover your changes (yes/no)?
these methods are not currently covered by unit test

### Did you update the documentation accordingly (yes/no)?
yes

### Did you read the CONTRIBUTING document (yes/no)?
yes
