### PR TITLE
Fixed regex bug causing invalid qcomponent files to be loaded.

### DIFF
--- a/qiskit_metal/_gui/widgets/qlibrary_display/proxy_model_qlibrary.py
+++ b/qiskit_metal/_gui/widgets/qlibrary_display/proxy_model_qlibrary.py
@@ -37,7 +37,7 @@ class LibraryFileProxyModel(QSortFilterProxyModel):
         # finds all files that
         # (Aren't hidden (begin w/ .), don't begin with __init__, don't begin with _template, etc. AND end in .py)  OR (don't begin with __pycache__ and don't have a '.' in the name   # pylint: disable=line-too-long
         # (QComponent files) OR (Directories)
-        self.accepted_files__regex = r"(^((?!\.))(?!__init__)(?!_template)(?!__pycache__).*\.py)|(?!__pycache__)(?!base)(^([^.]+)$)"  # pylint: disable=line-too-long
+        self.accepted_files__regex = r"(^((?!\.))(?!base)(?!__init__)(?!_template)(?!_parsed)(?!__pycache__).*\.py)|(?!__pycache__)(^([^.]+)$)"  # pylint: disable=line-too-long
         self.setFilterRegExp(self.accepted_files__regex)
 
     def filterAcceptsColumn(


### PR DESCRIPTION

### What are the issues this pull addresses (issue numbers / links)?
_parsed_dynamic_attrs.py and base.py were incorrectly being loaded as qcomponent files causing an error to pop up when clicking them. Below is an image of the error.

### Did you add tests to cover your changes (yes/no)?
no
### Did you update the documentation accordingly (yes/no)?
no
### Did you read the CONTRIBUTING document (yes/no)?
yes
### Summary


![Screen Shot 2021-09-30 at 9 49 41 AM](https://user-images.githubusercontent.com/90468712/135520623-ef143e57-c019-4789-a94e-b9cb73c6fb48.png)

### Details and comments


