### PR TITLE
Junction being added to GDS twice for positive mask with cheesing.

### DIFF
--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -1668,7 +1668,11 @@ class QGDSRenderer(QRenderer):
                 self.design.logger.warning(
                     'There is no table named diff_geometry to write.')
             else:
-                ground_cell.add(diff_geometry)
+                ground_chip_layer_name = f'ground_{chip_name}_{chip_layer}'
+                ground_chip_layer = lib.new_cell(ground_chip_layer_name)
+                #diff_geometry is a polygon set. So put into it's own cell.
+                ground_chip_layer.add(diff_geometry)
+                ground_cell.add(gdspy.CellReference(ground_chip_layer))
 
         self._handle_q_subtract_false(chip_name, chip_layer, ground_cell)
         QGDSRenderer._add_groundcell_to_chip_only_top(lib, chip_only_top,

--- a/qiskit_metal/renderers/renderer_gds/make_cheese.py
+++ b/qiskit_metal/renderers/renderer_gds/make_cheese.py
@@ -396,9 +396,9 @@ class Cheesing():
 
         # Still need to 'not' with Top_main_1 (ground)
         top_chip_layer_name = f'TOP_{self.chip_name}_{self.layer}'
+        ground_cell_name = f'ground_{self.chip_name}_{self.layer}'
         if top_chip_layer_name in self.lib.cells.keys():
-            ground_cell = self.lib.cells[top_chip_layer_name]
-
+            ground_cell = self.lib.cells[ground_cell_name]
             # Need to keep the depth at 0, otherwise all the
             # cell references (junctions) will be added for boolean.
             ground_cheese = gdspy.boolean(ground_cell.get_polygons(depth=0),

--- a/qiskit_metal/renderers/renderer_gds/make_cheese.py
+++ b/qiskit_metal/renderers/renderer_gds/make_cheese.py
@@ -398,7 +398,10 @@ class Cheesing():
         top_chip_layer_name = f'TOP_{self.chip_name}_{self.layer}'
         if top_chip_layer_name in self.lib.cells.keys():
             ground_cell = self.lib.cells[top_chip_layer_name]
-            ground_cheese = gdspy.boolean(ground_cell.get_polygons(),
+
+            # Need to keep the depth at 0, otherwise all the
+            # cell references (junctions) will be added for boolean.
+            ground_cheese = gdspy.boolean(ground_cell.get_polygons(depth=0),
                                           diff_holes_cell.get_polygonsets(),
                                           'not',
                                           max_points=self.max_points,


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Junction being added to GDS twice for positive mask with cheesing.  

### Did you add tests to cover your changes (yes/no)?
no

### Did you update the documentation accordingly (yes/no)?
The source code explains choice of arguments.

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
In the top_main_# for positive mask has the cell for junction in it as a reference. 
The cell top_main_# has paths and polys.  The other cells should not be part of the boolean subtraction.  For example the junction. 


### Details and comments
When getting the polygons, don't use the cells for junction.

