### PR TITLE
fixes #669 by updating main_window.py

### DIFF
--- a/qiskit_metal/_gui/main_window.py
+++ b/qiskit_metal/_gui/main_window.py
@@ -168,18 +168,20 @@ class QMainWindowExtension(QMainWindowExtensionBase):
                 self.design.save_path = filename
             # save python script to file path
             pyscript = self.design.to_python_script()
-            with open(filename, 'w') as f:
-                f.write(pyscript)
+            #check whether filename is empty or not. Save file only when filename is non-empty. 
+            if len(filename):
+                with open(filename, 'w') as f:
+                    f.write(pyscript)
 
-            #make it clear it's saving
-            saving_dialog = QDialog(self)
-            saving_dialog.setWindowModality(Qt.NonModal)
-            v = QVBoxLayout()
-            saving_dialog.setLayout(v)
-            v.addWidget(QLabel("Saving..."))
-            saving_dialog.open()
-            saving_dialog.show()
-            QTimer.singleShot(200, saving_dialog.close)
+                #make it clear it's saving
+                saving_dialog = QDialog(self)
+                saving_dialog.setWindowModality(Qt.NonModal)
+                v = QVBoxLayout()
+                saving_dialog.setLayout(v)
+                v.addWidget(QLabel("Saving..."))
+                saving_dialog.open()
+                saving_dialog.show()
+                QTimer.singleShot(200, saving_dialog.close)
         else:
             self.logger.info('No design present.')
             QMessageBox.warning(self, 'Warning', 'No design present! Can'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Issue #669 
https://github.com/Qiskit/qiskit-metal/issues/669

### Did you add tests to cover your changes (yes/no)?
no

### Did you update the documentation accordingly (yes/no)?
yes

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
Fixed the issue #669 by updating save_design function in qiskit_metal/_gui/main_window.py


### Details and comments
When using cancel instead of save, QFileDialog.getSaveFileName returns empty string(  https://github.com/Qiskit/qiskit-metal/blob/main/qiskit_metal/_gui/main_window.py#L163 ) as filename.
This caused a FileNotFoundError during opening of file (https://github.com/Qiskit/qiskit-metal/blob/main/qiskit_metal/_gui/main_window.py#L171). 

To fix the issue , an empty check was added. File will be opened and written to only if filename is non-empty (length of string is non-zero)

