### PR TITLE
Update open_to_ground.py

### DIFF
--- a/qiskit_metal/qlibrary/terminations/open_to_ground.py
+++ b/qiskit_metal/qlibrary/terminations/open_to_ground.py
@@ -24,21 +24,31 @@ class OpenToGround(QComponent):
     .. image::
         OpenToGround.png
 
-    .. meta::
-        Open to Ground
-
     Default Options:
-        * width: '10um' -- The width of the 'cpw' terminating to ground (this is merely
+        * width: 'cpw_width' -- The width of the 'cpw' terminating to ground (this is merely
           for the purpose of generating a value to pass to the pin)
-        * gap: '6um' -- The gap of the 'cpw'
-        * termination_gap: '6um' -- The length of dielectric from the end of the cpw center trace to the ground.
+        * gap: 'cpw_gap' -- The gap of the 'cpw'
+        * termination_gap: 'cpw_gap' -- The length of dielectric from the end of the cpw center trace to the ground.
+        * pos_x: '0um' -- The x position of the ground termination.
+        * pos_y: '0um' -- The y position of the ground termination.
+        * rotation: '0' -- The direction of the termination. 0 degrees is +x, following a
+          counter-clockwise rotation (eg. 90 is +y)
+        * chip: 'main' -- The chip the pin should be on.
+        * layer: '1' -- Layer the pin is on. Does not have any practical impact to the short.
 
     Values (unless noted) are strings with units included, (e.g., '30um')
     """
     component_metadata = Dict(short_name='term', _qgeometry_table_poly='True')
     """Component metadata"""
 
-    default_options = Dict(width='10um', gap='6um', termination_gap='6um')
+    default_options = Dict(width='cpw_width',
+                           gap='cpw_gap',
+                           termination_gap='cpw_gap',
+                           pos_x='0um',
+                           pos_y='0um',
+                           orientation='0',
+                           chip='main',
+                           layer='1')
     """Default connector options"""
 
     TOOLTIP = """A basic open to ground termination. """


### PR DESCRIPTION
open_to_ground default options were not generalized. width & gap and termination_gap was with some constant numbers so when One change their cpw_width and cpw_gap, open to ground's extra part was not changing accordingly.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes. 
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
open_to_ground default options were not generalized. width & gap and termination_gap was with some constant numbers so when One change their cpw_width and cpw_gap, open to ground's extra part was not changing accordingly.

### Did you add tests to cover your changes (yes/no)?
Yes
### Did you update the documentation accordingly (yes/no)?
Yes
### Did you read the CONTRIBUTING document (yes/no)?
Yes
### Summary
When One want to use different cpw_with and cpw_gap, the extra part (that makes the resonator not grounded) of open to the ground does not change because it was fixed as 10um and 6um, respectively. I changed them to cpw_width and cpw_gap as needed and it works now. Analyses also work. 


### Details and comments
Just updated some of the default options to have a generalized open to ground library.

