### PR TITLE
fixed bug when cap matrices have different sizes

### DIFF
--- a/qiskit_metal/analyses/quantization/lom_core_analysis.py
+++ b/qiskit_metal/analyses/quantization/lom_core_analysis.py
@@ -1160,7 +1160,8 @@ class CompositeSystem:
         self._jj = {k: j for c in self._cells for k, j in c.jj_dict.items()}
         _jj_to_node_map = dict(zip(self._jj.values(), self._jj.keys()))
 
-        _cell_nodes = np.unique([n for c in self._cells for n in c.nodes]).tolist()
+        _cell_nodes = np.unique([n for c in self._cells for n in c.nodes
+                                ]).tolist()
         _sys_nodes = []
         for sub in self._subsystems:
             for n in sub.nodes:

--- a/qiskit_metal/analyses/quantization/lom_core_analysis.py
+++ b/qiskit_metal/analyses/quantization/lom_core_analysis.py
@@ -1160,7 +1160,7 @@ class CompositeSystem:
         self._jj = {k: j for c in self._cells for k, j in c.jj_dict.items()}
         _jj_to_node_map = dict(zip(self._jj.values(), self._jj.keys()))
 
-        _cell_nodes = np.unique([c.nodes for c in self._cells]).tolist()
+        _cell_nodes = np.unique([n for c in self._cells for n in c.nodes]).tolist()
         _sys_nodes = []
         for sub in self._subsystems:
             for n in sub.nodes:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Fixed bug when cap matrices have different sizes. 

Need to flatten list of nodes before applying numpy.unique() 

### Did you add tests to cover your changes (yes/no)?

### Did you update the documentation accordingly (yes/no)?
yes

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary



### Details and comments


