### PR TITLE
Extend the infomation in name so that one component can have multiple…

### DIFF
--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -2035,7 +2035,7 @@ class QGDSRenderer(QRenderer):
             row, a_cell_bounding_box)
 
         # String for JJ combined with pad Right and pad Left
-        jj_pad_r_l_name = f'{row.gds_cell_name}_QComponent_is_{row.component}_Name_is_{row.name}'
+        jj_pad_r_l_name = f'{row.gds_cell_name}_QComponent_is_{row.component}_Name_is_{row.name}_name_is_{row.name}'
         temp_cell = lib.new_cell(jj_pad_r_l_name, overwrite_duplicate=True)
 
         if pad_left is not None:
@@ -2068,7 +2068,7 @@ class QGDSRenderer(QRenderer):
             row, a_cell_bounding_box)
 
         # String for JJ combined with pad Right and pad Left
-        jj_pad_r_l_name = f'pads_{row.gds_cell_name}_QComponent_is_{row.component}'
+        jj_pad_r_l_name = f'pads_{row.gds_cell_name}_QComponent_is_{row.component}_name_is_{row.name}'
         temp_cell = lib.new_cell(jj_pad_r_l_name, overwrite_duplicate=True)
         chip_only_top_layer.add(
             gdspy.CellReference(a_cell, origin=center, rotation=rotation))


### PR DESCRIPTION
… references  of one input junction.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
This closes Issue #773.  Users want to have more than one junction  in a component.  The junction is moved by reference and  pads are added.  I changed the name to include more information so each reference can be unique. 

### Did you add tests to cover your changes (yes/no)?
I did it manually and ask the person who had identified the issue.  He was happy with the fix.

### Did you update the documentation accordingly (yes/no)?
no

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
The fix makes the name of the cell longer so that it can be unique.


### Details and comments


