### PR TITLE
771 chipname and layer sub

### DIFF
--- a/qiskit_metal/qlibrary/core/base.py
+++ b/qiskit_metal/qlibrary/core/base.py
@@ -844,7 +844,8 @@ name='{strname}'{other_args}
             * input_as_norm (bool): Indicates if the points are tangent or normal to the pin plane.
               Defaults to False.. Make True for normal.
             * parent (Union[int,]): The id of the parent component.
-            * chip (str): the name of the chip the pin is located on.  Defaults to 'main'.
+            * chip (str): the name of the chip the pin is located on. Defaults to None, which is 
+            converted to self.options.chip.
             * gap (float): the dielectric gap of the pin for the purpose of representing as a port
               for simulations.  Defaults to None which is converted to 0.6 * width.
 
@@ -1093,8 +1094,9 @@ name='{strname}'{other_args}
             helper (bool): Is this a helper object. If true, subtract must be false
                            Defaults to False.
             layer (int, str): The layer to which the set of QGeometry will belong
-                              Defaults to 1.
-            chip (str): Chip name.  Defaults to 'main'.
+                              Defaults to None, which is converted to self.options.chip.
+            chip (str): Chip name. Defaults to None, which is converted to 
+            self.options.chip.
             kwargs (dict): Parameters dictionary
 
         Assumptions:

--- a/qiskit_metal/qlibrary/core/base.py
+++ b/qiskit_metal/qlibrary/core/base.py
@@ -830,7 +830,7 @@ name='{strname}'{other_args}
             points: np.ndarray,
             width: float,
             input_as_norm: bool = False,
-            chip: str = 'main',
+            chip: str = None,
             gap: float = None):  # gap defaults to 0.6 * width
         """Adds a pin from two points which are normal/tangent to the intended
         plane of the pin. The normal should 'point' in the direction of
@@ -894,6 +894,8 @@ name='{strname}'{other_args}
 
         if gap is None:
             gap = width * 0.6
+        if chip is None:
+            chip = self.options.chip
 
         rounding_val = self.design.template_options['PRECISION']
         points = np.around(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
add_pin() and add_qgeometry() were exclusively using the default values layer=1 and chip='main', since they have not been passed in by most QComponents' make() functions.

### Did you add tests to cover your changes (yes/no)?
no
### Did you update the documentation accordingly (yes/no)?
yes
### Did you read the CONTRIBUTING document (yes/no)?
yes
### Summary
Changed the default values to None, which then pull values from self.options. 


### Details and comments

