### PR TITLE
771 chipname and layer - Allow user to use chip name and layer other than the default. 

### DIFF
--- a/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -127,7 +127,7 @@ class LumpedElementsSim(QSimulation):
         """
         # save input variables to run(). This line must be the first in the method
         if components is not None:
-            argm = locals()
+            argm = dict(locals())
             del argm['self']
             self.save_run_args(**argm)
         # wipe data from the previous run (if any)

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -349,7 +349,9 @@ def to_vec3D(list_of_2d_pts: List[Tuple], z=0) -> np.ndarray:
         np.ndarray: vec3d of points
     """
     add_me = [z]
-    return np.array([list(a_2d_pt) + add_me for a_2d_pt in list_of_2d_pts])
+
+    vec3d = np.array([list(a_2d_pt) + add_me for a_2d_pt in list_of_2d_pts], dtype="object")
+    return vec3d
 
 
 Vec2D = Union[list, np.ndarray]

--- a/qiskit_metal/qlibrary/core/base.py
+++ b/qiskit_metal/qlibrary/core/base.py
@@ -830,7 +830,7 @@ name='{strname}'{other_args}
             points: np.ndarray,
             width: float,
             input_as_norm: bool = False,
-            chip: str = 'main',
+            chip: str = None,
             gap: float = None):  # gap defaults to 0.6 * width
         """Adds a pin from two points which are normal/tangent to the intended
         plane of the pin. The normal should 'point' in the direction of
@@ -844,7 +844,8 @@ name='{strname}'{other_args}
             * input_as_norm (bool): Indicates if the points are tangent or normal to the pin plane.
               Defaults to False.. Make True for normal.
             * parent (Union[int,]): The id of the parent component.
-            * chip (str): the name of the chip the pin is located on.  Defaults to 'main'.
+            * chip (str): the name of the chip the pin is located on. Defaults to None, which is 
+            converted to self.options.chip.
             * gap (float): the dielectric gap of the pin for the purpose of representing as a port
               for simulations.  Defaults to None which is converted to 0.6 * width.
 
@@ -894,6 +895,8 @@ name='{strname}'{other_args}
 
         if gap is None:
             gap = width * 0.6
+        if chip is None:
+            chip = self.options.chip
 
         rounding_val = self.design.template_options['PRECISION']
         points = np.around(
@@ -1091,8 +1094,9 @@ name='{strname}'{other_args}
             helper (bool): Is this a helper object. If true, subtract must be false
                            Defaults to False.
             layer (int, str): The layer to which the set of QGeometry will belong
-                              Defaults to 1.
-            chip (str): Chip name.  Defaults to 'main'.
+                              Defaults to None, which is converted to self.options.chip.
+            chip (str): Chip name. Defaults to None, which is converted to 
+            self.options.chip.
             kwargs (dict): Parameters dictionary
 
         Assumptions:

--- a/qiskit_metal/qlibrary/core/base.py
+++ b/qiskit_metal/qlibrary/core/base.py
@@ -635,7 +635,7 @@ gui = MetalGUI(design)
         str_failed = ""
         if len(failed) > 0:
             str_failed += """
-                       
+
             # WARNING"""
         for k in failed:
             str_failed += f"""
@@ -670,7 +670,7 @@ gui = MetalGUI(design)
         body = f"""
 {str_failed}
 {strname} = {obj_name}(
-design, 
+design,
 name='{strname}'{other_args}
 )
 {str_meta_d}
@@ -1073,8 +1073,8 @@ name='{strname}'{other_args}
             geometry: dict,
             subtract: bool = False,
             helper: bool = False,
-            layer: Union[int, str] = 1,  # chip will be here
-            chip: str = 'main',
+            layer: Union[int, str] = None,  # chip will be here
+            chip: str = None,
             **kwargs):
         r"""Add QGeometry.
 
@@ -1101,6 +1101,11 @@ name='{strname}'{other_args}
         """
         # assert (subtract and helper) == False, "The object can't be a subtracted helper. Please"\
         #    " choose it to either be a helper or a a subtracted layer, but not both. Thank you."
+
+        if layer is None:
+            layer = self.options.layer
+        if chip is None:
+            chip = self.options.chip
 
         if kind in self.qgeometry_table_usage.keys():
             self.qgeometry_table_usage[kind] = True

--- a/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
@@ -1362,6 +1362,11 @@ class QAnsysRenderer(QRendererAnalysis):
                 #    self.chip_not_main()
                 #    return []
                 chip_names.add(icomps[qcomp_id].options.chip)
+
+        for unique_name in chip_names:
+            if unique_name not in self.design.chips:
+                self.chip_not_in_design_error(unique_name)
+
         return list(chip_names)
 
     def chip_designation_error(self):
@@ -1371,6 +1376,16 @@ class QAnsysRenderer(QRendererAnalysis):
         """
         self.logger.warning(
             "This component currently lacks a chip designation. Please add chip='main' to the component's default_options dictionary, restart the kernel, and try again."
+        )
+    
+    def chip_not_in_design_error(self, missing_chip:str):
+        """
+        Warning message that appears when the Ansys renderer fails to locate a component's chip designation in DesignPlanar (or any child of QDesign).
+        Provides instructions for a temporary workaround until the layer stack is finalized.
+        """
+        self.logger.warning(
+            f'This component currently lacks a chip designation in DesignPlanar, or any child of QDesign. '
+            f'Please add dict for chip=\'{missing_chip}\' in DesignPlanar, or child of QDesign. Then restart the kernel, and try again.'
         )
 
     def chip_not_main(self):

--- a/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -123,10 +123,13 @@ class QQ3DRenderer(QAnsysRenderer):
             self.logger.warning(
                 'Unable to proceed with rendering. Please check selection.')
             return
-
+        
         self.chip_subtract_dict = defaultdict(set)
         self.assign_perfE = []
         self.assign_mesh = []
+
+        chip_list = self.get_chip_names()
+        
 
         self.render_tables(skip_junction=True)
         self.add_endcaps(open_pins)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
After merge, this will close issue 771. 

### Did you add tests to cover your changes (yes/no)?
no

### Did you update the documentation accordingly (yes/no)?
This code fixes what the documentation has presented already.

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
@rparkerparkerr  found the issue and provided the fix.  I added a warning and tested with Ansys Q3d. 


### Details and comments


