### PR TITLE
Updated the component name for GUI

### DIFF
--- a/qiskit_metal/qlibrary/qubits/transmon_pocket_cl.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_pocket_cl.py
@@ -60,7 +60,7 @@ class TransmonPocketCL(TransmonPocket):  # pylint: disable=invalid-name
         transmon_pocket_cl.png
 
     .. meta::
-        Transmon Pocket Connector Lines
+        Transmon Pocket Charge Line
 
     BaseQubit Default Options:
         * connection_pads: empty Dict -- The dictionary which contains all active connection lines for the qubit.


### PR DESCRIPTION
The name of the component- Transmon Pocket Connector Lines has been replaced with - Transmon Pocket Charge Line

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
#809 

### Did you add tests to cover your changes (yes/no)?
Tested by re-running Metal GUI
### Did you update the documentation accordingly (yes/no)?
Yes
### Did you read the CONTRIBUTING document (yes/no)?
Yes
### Summary
The name of the component- Transmon Pocket Connector Lines has been replaced with - Transmon Pocket Charge Line



### Details and comments
N/A

