### PR TITLE
Added 3D vector class

### DIFF
--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -828,7 +828,7 @@ class Vec3D(Vector):
         Returns:
             float: azimuthal angle of vector
         """
-        return np.arctan2(*vec[:2])
+        return np.arctan2(*vec[:2][::-1])
 
     @staticmethod
     def two_points_described(points2D: List[np.ndarray]) -> Tuple[np.ndarray]:

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -888,10 +888,12 @@ class Vec3D(Vector):
             points3D = np.array(points3D)
 
         # Check if both points are on the user_plane
-        pt1_on_plane = True if (user_plane.dot(np.append(points3D[0], [1]))
-                                == 0) else False
-        pt2_on_plane = True if (user_plane.dot(np.append(points3D[1], [1]))
-                                == 0) else False
+        pt1_on_plane = True if (np.round(user_plane.dot(
+            np.append(points3D[0], [1])),
+                                         decimals=PRECISION) == 0) else False
+        pt2_on_plane = True if (np.round(user_plane.dot(
+            np.append(points3D[1], [1])),
+                                         decimals=PRECISION) == 0) else False
 
         if pt1_on_plane and pt2_on_plane:
             distance_vec = points3D[0] - points3D[1]

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -506,6 +506,7 @@ class Vector:
         """
         return norm(vec)
 
+    @staticmethod
     def are_same(v1: Vec2D, v2: Vec2D, tol: int = 100) -> bool:
         """Check if two vectors are within an infinitesimal distance set by
         `tol` and machine epsilon.
@@ -609,3 +610,221 @@ class Vector:
         v[m] = np.sign(vec_n[m])
         vec_n = v
         return vec_n
+
+
+class Vec3D(Vector):
+    """Class to define a 3D vector and perform operations on them.
+
+    Returns:
+        Vec3D: A 3-dimensional vector object
+    """
+
+    @staticmethod
+    def norm(vec: np.ndarray) -> float:
+        """Magnitude of the vector
+
+        Args:
+            vec (np.ndarray): input vector
+
+        Returns:
+            float: magnitude of the vector calculated by Frobenius norm
+        """
+        return np.round(np.linalg.norm(vec), decimals=9)
+
+    @staticmethod
+    def normed(vec: np.adarray):
+        """Normed vector
+
+        Args:
+            vec (np.ndarray): input vector
+
+        Returns:
+            np.ndarray: normed vector
+        """
+        return vec / Vec3D.norm(vec)
+
+    @staticmethod
+    def add(vec: np.ndarray, other: np.ndarray):
+        """Adds two vectors
+
+        Args:
+            vec (np.ndarray): input vector
+            other (np.ndarray): the other vector
+
+        Returns:
+            np.ndarray: resultant vector
+        """
+        return (vec + other)
+
+    @staticmethod
+    def dot(vec: np.adarray, other: np.ndarray) -> float:
+        """Dot product of two vectors
+
+        Args:
+            vec (np.ndarray): input vector
+            other (np.ndarray): the other vector
+
+        Returns:
+            float: result from dot product
+        """
+        return np.round(vec.dot(other), decimals=9)
+
+    @staticmethod
+    def cross(vec: np.ndarray, other: np.ndarray):
+        """Cross product of two vectors
+
+        Args:
+            vec (np.ndarray): input vector
+            other (np.ndarray): the other vector
+
+        Returns:
+            np.ndarray: resultant vector
+        """
+        return np.round(np.cross(vec, other), decimals=9)
+
+    @staticmethod
+    def sub(vec: np.ndarray, other: np.ndarray):
+        """Difference between two vectors
+
+        Args:
+            vec (np.ndarray): input vector
+            other (np.ndarray): the other vector
+
+        Returns:
+            np.ndarray: resultant vector
+        """
+        return (vec - other)
+
+    @staticmethod
+    def scale(vec: np.ndarray, value: Union[int, float]):
+        """Multiply the vector with a scalar
+
+        Args:
+            vec (np.ndarray): input vector
+            value (Union[int, float]): scalar value
+
+        Returns:
+            np.ndarray: resultant vector
+        """
+        return (vec * value)
+
+    @staticmethod
+    def get_distance(vec: np.ndarray, other: np.ndarray) -> float:
+        """Calculate Euler distance between two vectors
+
+        Args:
+            vec (np.ndarray): input vector
+            other (np.ndarray): the other vector
+
+        Returns:
+            float: Euler distance
+        """
+        return np.round(Vec3D.norm(vec - other), decimals=9)
+
+    @staticmethod
+    def translate(vec: np.ndarray, translate_vec: np.ndarray):
+        """Translate a vector
+
+        Args:
+            vec (np.ndarray): vector to transform
+            translate_vec (np.ndarray): translation values as a vector
+
+        Returns:
+            np.ndarray: return a new np.ndarray object
+        """
+        return Vec3D.add(vec, translate_vec)
+
+    @staticmethod
+    def rotate(vec: np.ndarray,
+               cvec: np.ndarray,
+               ax: bool = False,
+               ay: bool = False,
+               az: bool = False,
+               radians: float = 0.0):
+        """Rotate a vector
+
+        Args:
+            vec (np.ndarray): vector to transform
+            cvec (np.ndarray): center of rotation as a vector
+            ax (bool, optional): Rotate around x-axis. Defaults to False.
+            ay (bool, optional): Rotate around y-axis. Defaults to False.
+            az (bool, optional): Rotate around z-axis. Defaults to False.
+            radians (float, optional): radians of rotation. Defaults to 0.0.
+
+        Returns:
+            np.ndarray: return a new np.ndarray object
+        """
+
+        if ax:
+            rot_x = np.array([[1, 0, 0], [0,
+                                          np.cos(radians), -np.sin(radians)],
+                              [0, np.sin(radians),
+                               np.cos(radians)]])
+            translate_vec = np.array([0, cvec[1], cvec[2]])
+            new_vec = rot_x.dot((vec - translate_vec)) + translate_vec
+
+        if ay:
+            rot_y = np.array([[np.cos(radians), 0,
+                               np.sin(radians)], [0, 1, 0],
+                              [-np.sin(radians), 0,
+                               np.cos(radians)]])
+            translate_vec = np.array([cvec[0], 0, cvec[2]])
+            new_vec = rot_y.dot((vec - translate_vec)) + translate_vec
+
+        if az:
+            rot_z = np.array([[np.cos(radians), -np.sin(radians), 0],
+                              [np.sin(radians),
+                               np.cos(radians), 0], [0, 0, 1]])
+            translate_vec = np.array([cvec[0], cvec[1], 0])
+            new_vec = rot_z.dot((vec - translate_vec)) + translate_vec
+
+        return new_vec
+
+    @staticmethod
+    def angle_elevation(vec: np.ndarray) -> float:
+        """Returns the elevation angle of vector
+
+        Args:
+            vec (np.ndarray): input vector
+
+        Returns:
+            float: elevation angle in radians
+        """
+        unit_z = np.array([0, 0, 1])
+        unit_self = Vec3D.normed(vec)
+        return np.arccos(unit_self.dot(unit_z))
+
+    @staticmethod
+    def angle_azimuth(vec: np.ndarray) -> float:
+        """Returns the azimuthal angle of vector
+
+        Args:
+            vec (np.ndarray): input vector
+
+        Returns:
+            float: azimuthal angle of vector
+        """
+        return np.arctan2(vec[:2])
+
+    @staticmethod
+    def two_points_described(points2D: list[np.ndarray]) -> Tuple[np.ndarray]:
+        raise NotImplementedError(
+            "This method does not need to be implemented for 3D.")
+
+    @staticmethod
+    def add_z(vec2D: np.array, z: float = 0.):
+        raise NotImplementedError(
+            "This method does not need to be implemented for 3D.")
+
+    @staticmethod
+    def angle(vector: Vec2D) -> float:
+        raise NotImplementedError(
+            """This method is implemented by 'angle_azimuth' method for 3D vector.
+            Please use that instead.""")
+
+    @staticmethod
+    def rotate_around_point(xy: Vec2D, radians: float,
+                            origin=(0, 0)) -> np.ndarray:
+        raise NotImplementedError(
+            """This method is implemented by 'rotate' method for 3D vector.
+            Please use that instead.""")

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -862,9 +862,45 @@ class Vec3D(Vector):
         return new_vec
 
     @staticmethod
-    def two_points_described(points2D: List[np.ndarray]) -> Tuple[np.ndarray]:
-        raise NotImplementedError(
-            "This method does not need to be implemented for 3D.")
+    def two_points_described(points3D: List[np.ndarray],
+                             user_plane: np.ndarray) -> Tuple[np.ndarray]:
+        """Get the distance, units and tangents.
+
+        Args:
+            points3D (List[np.ndarray]): 3D list of points
+            user_plane (np.ndarray): 2D plane containing the input points and
+                                    defined by coefficients A,B,C,D in
+                                    equation (Ax + By + Cz + D = 0)
+
+        Returns:
+            tuple: (distance_vec, dist_unit_vec, tangent_vec) -- Each is a vector np.array
+        """
+        if len(points3D) != 2:
+            raise ValueError(f"Expected only 2 points, found {len(points3D)}.")
+        if len(user_plane) != 4:
+            raise ValueError(
+                f"""Expected all four coefficients A,B,C,D for the plane.
+                Found {len(user_plane)} instead.""")
+
+        if not isinstance(user_plane, np.ndarray):
+            user_plane = np.array(user_plane)
+        if not isinstance(points3D, np.ndarray):
+            points3D = np.array(points3D)
+
+        # Check if both points are on the user_plane
+        pt1_on_plane = True if (user_plane.dot(np.append(points3D[0], [1]))
+                                == 0) else False
+        pt2_on_plane = True if (user_plane.dot(np.append(points3D[1], [1]))
+                                == 0) else False
+
+        if pt1_on_plane and pt2_on_plane:
+            distance_vec = points3D[0] - points3D[1]
+            dist_unit_vec = Vec3D.normed(distance_vec)
+            plane_normal = Vec3D.normed(user_plane[:3])
+            tangent_vec = Vec3D.cross(dist_unit_vec, plane_normal)
+            return distance_vec, dist_unit_vec, tangent_vec
+        else:
+            raise ValueError("Either one or both points not on the user_plane.")
 
     @staticmethod
     def add_z(vec2D: np.array, z: float = 0.):

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -831,7 +831,7 @@ class Vec3D(Vector):
         return np.arctan2(*vec[:2])
 
     @staticmethod
-    def two_points_described(points2D: list[np.ndarray]) -> Tuple[np.ndarray]:
+    def two_points_described(points2D: List[np.ndarray]) -> Tuple[np.ndarray]:
         raise NotImplementedError(
             "This method does not need to be implemented for 3D.")
 

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -632,7 +632,7 @@ class Vec3D(Vector):
         return np.round(np.linalg.norm(vec), decimals=9)
 
     @staticmethod
-    def normed(vec: np.adarray):
+    def normed(vec: np.ndarray):
         """Normed vector
 
         Args:
@@ -641,6 +641,8 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: normed vector
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
         return vec / Vec3D.norm(vec)
 
     @staticmethod
@@ -654,10 +656,14 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: resultant vector
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
+        if not isinstance(other, np.ndarray):
+            other = np.array(other)
         return (vec + other)
 
     @staticmethod
-    def dot(vec: np.adarray, other: np.ndarray) -> float:
+    def dot(vec: np.ndarray, other: np.ndarray) -> float:
         """Dot product of two vectors
 
         Args:
@@ -667,6 +673,10 @@ class Vec3D(Vector):
         Returns:
             float: result from dot product
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
+        if not isinstance(other, np.ndarray):
+            other = np.array(other)
         return np.round(vec.dot(other), decimals=9)
 
     @staticmethod
@@ -693,6 +703,10 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: resultant vector
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
+        if not isinstance(other, np.ndarray):
+            other = np.array(other)
         return (vec - other)
 
     @staticmethod
@@ -706,6 +720,8 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: resultant vector
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
         return (vec * value)
 
     @staticmethod
@@ -719,6 +735,10 @@ class Vec3D(Vector):
         Returns:
             float: Euler distance
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
+        if not isinstance(other, np.ndarray):
+            other = np.array(other)
         return np.round(Vec3D.norm(vec - other), decimals=9)
 
     @staticmethod
@@ -754,6 +774,10 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: return a new np.ndarray object
         """
+        if not isinstance(vec, np.ndarray):
+            vec = np.array(vec)
+        if not isinstance(cvec, np.ndarray):
+            cvec = np.array(cvec)
 
         if ax:
             rot_x = np.array([[1, 0, 0], [0,
@@ -804,7 +828,7 @@ class Vec3D(Vector):
         Returns:
             float: azimuthal angle of vector
         """
-        return np.arctan2(vec[:2])
+        return np.arctan2(*vec[:2])
 
     @staticmethod
     def two_points_described(points2D: list[np.ndarray]) -> Tuple[np.ndarray]:
@@ -828,3 +852,8 @@ class Vec3D(Vector):
         raise NotImplementedError(
             """This method is implemented by 'rotate' method for 3D vector.
             Please use that instead.""")
+
+    @staticmethod
+    def snap_unit_vector(vec_n: Vec2D, flip: bool = False) -> Vec2D:
+        raise NotImplementedError(
+            """This method is not implemented for 3D vector.""")

--- a/qiskit_metal/draw/utility.py
+++ b/qiskit_metal/draw/utility.py
@@ -37,6 +37,9 @@ __all__ = [
     'vec_unit_planar', 'Vector'
 ]
 
+# Used for numpy.round()
+PRECISION = 10
+
 #########################################################################
 # Shapely Geometry Basic Coordinates
 
@@ -453,6 +456,7 @@ class Vector:
     @staticmethod
     def angle_between(v1: Vec2D, v2: Vec2D) -> float:
         """Returns the angle in radians between vectors 'v1' and 'v2'.
+        Disclaimer: The same method is also used Vec3D as it is flexible enough.
 
         Args:
             v1 (Vec2D): First vector
@@ -510,6 +514,7 @@ class Vector:
     def are_same(v1: Vec2D, v2: Vec2D, tol: int = 100) -> bool:
         """Check if two vectors are within an infinitesimal distance set by
         `tol` and machine epsilon.
+        Disclaimer: The same method is also used Vec3D as it is flexible enough.
 
         Args:
             v1 (Vec2D): First vector to check
@@ -583,7 +588,8 @@ class Vector:
         # unit vector along the direction of the two point
         unit_vec = distance_vec / norm(distance_vec)
         # tangent vector counter-clockwise 90 deg rotation
-        tangent_vec = np.round(Vector.rotate(unit_vec, np.pi / 2), decimals=11)
+        tangent_vec = np.round(Vector.rotate(unit_vec, np.pi / 2),
+                               decimals=PRECISION)
 
         if Vector.is_zero(distance_vec):
             logger.debug(
@@ -629,7 +635,7 @@ class Vec3D(Vector):
         Returns:
             float: magnitude of the vector calculated by Frobenius norm
         """
-        return np.round(np.linalg.norm(vec), decimals=9)
+        return np.round(np.linalg.norm(vec), decimals=PRECISION)
 
     @staticmethod
     def normed(vec: np.ndarray):
@@ -677,7 +683,7 @@ class Vec3D(Vector):
             vec = np.array(vec)
         if not isinstance(other, np.ndarray):
             other = np.array(other)
-        return np.round(vec.dot(other), decimals=9)
+        return np.round(vec.dot(other), decimals=PRECISION)
 
     @staticmethod
     def cross(vec: np.ndarray, other: np.ndarray):
@@ -690,7 +696,7 @@ class Vec3D(Vector):
         Returns:
             np.ndarray: resultant vector
         """
-        return np.round(np.cross(vec, other), decimals=9)
+        return np.round(np.cross(vec, other), decimals=PRECISION)
 
     @staticmethod
     def sub(vec: np.ndarray, other: np.ndarray):
@@ -739,7 +745,7 @@ class Vec3D(Vector):
             vec = np.array(vec)
         if not isinstance(other, np.ndarray):
             other = np.array(other)
-        return np.round(Vec3D.norm(vec - other), decimals=9)
+        return np.round(Vec3D.norm(vec - other), decimals=PRECISION)
 
     @staticmethod
     def translate(vec: np.ndarray, translate_vec: np.ndarray):
@@ -831,6 +837,31 @@ class Vec3D(Vector):
         return np.arctan2(*vec[:2][::-1])
 
     @staticmethod
+    def snap_unit_vector(vec: np.ndarray, snap_to: str = None) -> Vec2D:
+        """Snaps to either the x, y or z unit vectors with sign.
+
+        Args:
+            vec_n (np.ndarray): 3D vector
+            snap_to (str): Snap to direction with max projection length by default.
+                            Snap to particular axis if specified.
+
+        Returns:
+            np.ndarray: Snapped vector
+        """
+        if snap_to is None:
+            idx = np.argmax(np.abs(vec))
+        else:
+            valid_snap_to = ["x", "y", "z"]
+            if snap_to not in valid_snap_to:
+                raise ValueError(
+                    "The argument 'snap_to' should be one of 'x', 'y', or 'z'.")
+            idx = valid_snap_to.index(snap_to)
+
+        new_vec = np.array([0, 0, 0])
+        new_vec[idx] = np.sign(vec[idx])
+        return new_vec
+
+    @staticmethod
     def two_points_described(points2D: List[np.ndarray]) -> Tuple[np.ndarray]:
         raise NotImplementedError(
             "This method does not need to be implemented for 3D.")
@@ -852,8 +883,3 @@ class Vec3D(Vector):
         raise NotImplementedError(
             """This method is implemented by 'rotate' method for 3D vector.
             Please use that instead.""")
-
-    @staticmethod
-    def snap_unit_vector(vec_n: Vec2D, flip: bool = False) -> Vec2D:
-        raise NotImplementedError(
-            """This method is not implemented for 3D vector.""")

--- a/qiskit_metal/tests/test_draw.py
+++ b/qiskit_metal/tests/test_draw.py
@@ -595,7 +595,7 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
         """Test angle_azimuth in the Vec3D class in utility.py"""
         vec3d = Vec3D()
 
-        expected = np.pi / 2
+        expected = 0
         actual = vec3d.angle_azimuth([1, 0, 0])
         self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
 

--- a/qiskit_metal/tests/test_draw.py
+++ b/qiskit_metal/tests/test_draw.py
@@ -570,7 +570,7 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
                          radians=np.radians(-45)))
 
         for i in range(2):
-            for j in range(2):
+            for j in range(3):
                 self.assertAlmostEqualRel(actual[i][j],
                                           expected[i][j],
                                           rel_tol=1e-3)
@@ -752,6 +752,87 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
 
         for i in range(2):
             self.assertAlmostEqualRel(actual[i], expected[i], rel_tol=1e-3)
+
+    def test_draw_vec3d_add(self):
+        """Test add in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [[3, 5, 6], [4.5, 6.75, 10.635]]
+        actual = []
+        actual.append(vec3d.add([1, 2, 5], [2, 3, 1]))
+        actual.append(vec3d.add([1, 3.75, 5.13], [3.5, 3, 5.505]))
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
+    def test_draw_vec3d_sub(self):
+        """Test sub in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [[3, 5, 6], [4, 6.75, 10.635]]
+        actual = []
+        actual.append(vec3d.sub([5, 8, 7], [2, 3, 1]))
+        actual.append(vec3d.sub([7.5, 9.75, 16.14], [3.5, 3, 5.505]))
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
+    def test_draw_vec3d_scale(self):
+        """Test scale in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [[2, 4, 8], [4, 14, 16]]
+        actual = []
+        actual.append(vec3d.scale([1, 2, 4], 2))
+        actual.append(vec3d.scale([1, 3.5, 4], 4))
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
+    def test_draw_vec3d_translate(self):
+        """Test translate in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [[3, -1, 4], [4.5, 0.75, -1.43]]
+        actual = []
+        actual.append(vec3d.translate([1, 2, 3], [2, -3, 1]))
+        actual.append(vec3d.translate([1, 3.75, 5.57], [3.5, -3, -7]))
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
+    def test_draw_vec3d_dot(self):
+        """Test dot in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [2, 0]
+        actual = []
+        actual.append(vec3d.dot([1, 0, 0], [2, 0, 0]))
+        actual.append(vec3d.dot([1, 0, 0], [0, 1, 0]))
+        for i in range(2):
+            self.assertAlmostEqualRel(actual[i], expected[i], rel_tol=1e-3)
+
+    def test_draw_vec3d_cross(self):
+        """Test cross in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [[-1, 2, -1], [7.875, 12.75, -10.125]]
+        actual = []
+        actual.append(vec3d.cross([1, 2, 3], [2, 3, 4]))
+        actual.append(vec3d.cross([1, 3.75, 5.5], [3.5, 3, 6.5]))
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
 
 
 if __name__ == '__main__':

--- a/qiskit_metal/tests/test_draw.py
+++ b/qiskit_metal/tests/test_draw.py
@@ -29,7 +29,7 @@ from shapely.geometry import JOIN_STYLE
 
 from qiskit_metal.draw import basic
 from qiskit_metal.draw import utility
-from qiskit_metal.draw.utility import Vector
+from qiskit_metal.draw.utility import Vector, Vec3D
 from qiskit_metal.tests.assertions import AssertionsMixin
 
 
@@ -553,12 +553,58 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
                                           expected[i][j],
                                           rel_tol=1e-3)
 
+    def test_draw_vec3d_rotate(self):
+        """Test rotate in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [(1, 1, 0), (0, 1, -1)]
+
+        actual = []
+        actual.append(
+            vec3d.rotate([np.sqrt(2), 0, 0], [0, 0, 0],
+                         az=True,
+                         radians=np.radians(45)))
+        actual.append(
+            vec3d.rotate([0, np.sqrt(2), 0], [0, 0, 0],
+                         ax=True,
+                         radians=np.radians(-45)))
+
+        for i in range(2):
+            for j in range(2):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
     def test_draw_vector_angle_between(self):
         """Test angle_between in Vector class in utility.py."""
         vector = Vector()
 
         expected = 0.6435011087932843
         actual = vector.angle_between([0, 10], [15, 20])
+        self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
+
+    def test_draw_vec3d_angle_between(self):
+        """Test angle_between in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = np.pi / 2
+        actual = vec3d.angle_between([1, 0, 0], [0, 1, 0])
+        self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
+
+    def test_draw_vec3d_angle_azimuth(self):
+        """Test angle_azimuth in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = np.pi / 2
+        actual = vec3d.angle_azimuth([1, 0, 0])
+        self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
+
+    def test_draw_vec3d_angle_elevation(self):
+        """Test angle_elevation in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = np.pi / 2
+        actual = vec3d.angle_elevation([1, 0, 0])
         self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
 
     def test_draw_vector_add_z(self):
@@ -585,12 +631,30 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
         self.assertEqual(result[0], 0.6)
         self.assertEqual(result[1], 0.8)
 
+    def test_draw_vec3d_normed(self):
+        """Test normed in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = np.array([1, 0, 2]) / np.sqrt(5)
+
+        actual = vec3d.normed([10, 0, 20])
+        for i in range(3):
+            self.assertAlmostEqualRel(actual[i], expected[i], rel_tol=1e-3)
+
     def test_draw_vector_norm(self):
         """Test norm in Vector class in utility.py."""
         vector = Vector()
 
         expected = 18.138357147217054
         actual = vector.norm([10, 15, 2])
+        self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
+
+    def test_draw_vec3d_norm(self):
+        """Test norm in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = np.sqrt(5) * 10
+        actual = vec3d.norm([10, 0, 20])
         self.assertAlmostEqualRel(actual, expected, rel_tol=1e-3)
 
     def test_draw_vector_are_same(self):
@@ -672,6 +736,19 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
         actual = []
         actual.append(vector.get_distance((1, 1), (2, 2), precision=2))
         actual.append(vector.get_distance((10, 15), (22, -6), precision=3))
+
+        for i in range(2):
+            self.assertAlmostEqualRel(actual[i], expected[i], rel_tol=1e-3)
+
+    def test_draw_vec3d_get_distance(self):
+        """Test get_distance in the Vec3D class in utility.py"""
+        vec3d = Vec3D()
+
+        expected = [1.732, 1.414]
+
+        actual = []
+        actual.append(vec3d.get_distance([0, 0, 0], [1, 1, 1]))
+        actual.append(vec3d.get_distance([1, 0, 1], [0, 0, 0]))
 
         for i in range(2):
             self.assertAlmostEqualRel(actual[i], expected[i], rel_tol=1e-3)

--- a/qiskit_metal/tests/test_draw.py
+++ b/qiskit_metal/tests/test_draw.py
@@ -853,6 +853,27 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
                                           expected[i][j],
                                           rel_tol=1e-3)
 
+    def test_draw_vec3d_two_points_described(self):
+        """Test two_points_described in Vec3D class in utility.py."""
+        vec3d = Vec3D()
+
+        expected = [([0, 0, -2], [0, 0, -1], [1, 0, 0]),
+                    ([0, 0, -2], [0, 0, -1], [0, -1, 0])]
+
+        actual = []
+        actual.append(
+            vec3d.two_points_described([[1, 0, 2], [1, 0, 4]], [0, 1, 0, 0]))
+        actual.append(
+            vec3d.two_points_described([[0, 1, 2], [0, 1, 4]], [1, 0, 0, 0]))
+
+        for i in range(2):
+            for j in range(3):
+                for k in range(3):
+                    print(i, j, k)
+                    self.assertAlmostEqualRel(actual[i][j][k],
+                                              expected[i][j][k],
+                                              rel_tol=1e-3)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/qiskit_metal/tests/test_draw.py
+++ b/qiskit_metal/tests/test_draw.py
@@ -727,6 +727,25 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
                                           expected[i][j],
                                           rel_tol=1e-3)
 
+    def test_draw_vec3d_snap_unit_vector(self):
+        """Test snap_unit_vector in Vec3D class in utility.py."""
+        vec3d = Vec3D()
+
+        expected = [[0, 0, 1], [0, 1, 0], [-1, 0, 0]]
+
+        data = np.array([-10., 15., 20])
+
+        actual = []
+        actual.append(vec3d.snap_unit_vector(data))
+        actual.append(vec3d.snap_unit_vector(data, snap_to='y'))
+        actual.append(vec3d.snap_unit_vector(data, snap_to='x'))
+
+        for i in range(2):
+            for j in range(3):
+                self.assertAlmostEqualRel(actual[i][j],
+                                          expected[i][j],
+                                          rel_tol=1e-3)
+
     def test_draw_get_distance(self):
         """Test the functionality of get_distance in utility.py."""
         vector = Vector()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
#808 

### Did you add tests to cover your changes (yes/no)?
Yes. Modified `qiskit_metal/tests/test_draw.py` to include tests for new code.

### Did you update the documentation accordingly (yes/no)?
Yes

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
Added a 3D vector class `Vec3D` for extending functionality to be used by future renderers (like Gmsh).


### Details and comments
Gmsh renderer uses 3D vectors natively to avoid the conversion and confusion between 2D and 3D vectors. this class adds the feature to use 3D vectors and extends the functionality.

