### PR TITLE
Bump version of qiskit-metal pyEPR version for EPR sign fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - numpy
   - pandas
   - pint
-  - pyepr-quantum>=0.8.5.5
+  - pyepr-quantum>=0.8.5.6
   - pygments
   - pyside2
   - qutip

--- a/qiskit_metal/__init__.py
+++ b/qiskit_metal/__init__.py
@@ -15,7 +15,7 @@
 # pylint: disable=wrong-import-order
 # pylint: disable=wrong-import-position
 """Qiskit Metal"""
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __license__ = "Apache 2.0"
 __copyright__ = 'Copyright IBM 2019-2020'
 __author__ = 'Zlatko Minev, Thomas McConkey, and them IBM Quantum Team'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib
 numpy
 pandas
 pint
-pyEPR-quantum>=0.8.5.5
+pyEPR-quantum>=0.8.5.6
 pygments
 pyside2
 qutip

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open(here / "requirements.txt", encoding="utf-8") as f:
 
 setup(
     name="qiskit_metal",
-    version="0.1.0",
+    version="0.1.1",
     description="Qiskit Metal | for quantum device design & analysis",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
N/A

### Did you add tests to cover your changes (yes/no)?
No
### Did you update the documentation accordingly (yes/no)?
No
### Did you read the CONTRIBUTING document (yes/no)?
Yes
### Summary
This PR bumps the version numbers for qiskit metal and pyEPR to pull in a pyEPR fix to a bug that was causing EPR to always be positive.


### Details and comments
Qiskit-metal version bumped from 0.1.0 to 0.1.1
pyEPR version bumped from 0.8.5.5 to 0.8.5.6

