### PR TITLE
Fix for including mesh size fields in `.geo_unrolled` file and SetFactory()

### DIFF
--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1233,7 +1233,23 @@ class QGmshRenderer(QRenderer):
         if not os.path.exists(par_dir):
             raise ValueError(f"Directory not found: {par_dir}")
 
+        has_mesh = False if len(gmsh.model.mesh.field.list()) == 0 else True
+        if has_mesh:
+            self.logger.warning(
+                "WARNING: The existing model contains mesh size field definitions, "
+                "which will show up in your exported .geo_unrolled file. If "
+                "you aren't explicitly handling the mesh size fields, we recommend "
+                "to export the geometry before generating the mesh in your design as "
+                "it might interfere with your .geo_unrolled file imports.")
+
         gmsh.write(filepath)
+
+        # Prepend "SetFactory("OpenCASCADE");" in the exported file
+        line = 'SetFactory("OpenCASCADE");'
+        with open(filepath, 'r+') as f:
+            content = f.read()
+            f.seek(0, 0)
+            f.write(line.rstrip('\r\n') + '\n' + content)
 
     def import_post_processing_data(self,
                                     filename: str,

--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -808,8 +808,9 @@ class QGmshRenderer(QRenderer):
             fragmented_geoms = gmsh.model.occ.fragment([object_dimtag],
                                                        all_geom_dimtags)
 
-        all_geom_dimtags.insert(0, object_dimtag)
         updated_geoms = fragmented_geoms[0]
+        insert_idx = updated_geoms.index(object_dimtag)
+        all_geom_dimtags.insert(insert_idx, object_dimtag)
         all_dicts = {
             0: self.paths_dict,
             1: self.polys_dict,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes #857 

### Did you add tests to cover your changes (yes/no)?
Did external testing

### Did you update the documentation accordingly (yes/no)?
No

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
Added some code to fix the exported `.geo_unrolled` file from Gmsh renderer to not have mesh size fields and also set the factory method to "OpenCASCADE" in the file manually.


### Details and comments
N/A

