### PR TITLE
Fix for Gmsh renderer not assigning physical group to dielectric volumes

### DIFF
--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -874,7 +874,10 @@ class QGmshRenderer(QRenderer):
                 for name, tag in layer_geoms.items():
                     if layer_dim == 3:
                         tags = gmsh.model.occ.getSurfaceLoops(tag[0])[1][0]
-                        if not ignore_metal_volume:
+                        metal_layer = True if layer in self.layer_types[
+                            "metal"] else False
+                        if not metal_layer or (metal_layer and
+                                               not ignore_metal_volume):
                             ph_vol_tag = gmsh.model.addPhysicalGroup(
                                 dim=layer_dim, tags=tag, name=name)
                             self.physical_groups[layer][name] = ph_vol_tag
@@ -918,7 +921,9 @@ class QGmshRenderer(QRenderer):
                         layer_sfs_tags += list(
                             gmsh.model.occ.getSurfaceLoops(vol)[1][0])
 
-                    if layer_type == "ground_plane" and not ignore_metal_volume:
+                    if layer_type != "ground_plane" or (
+                            layer_type == "ground_plane" and
+                            not ignore_metal_volume):
                         ph_vol_tag = gmsh.model.addPhysicalGroup(
                             dim=layer_dim, tags=layer_tag, name=layer_name)
                         self.physical_groups[layer][layer_name] = ph_vol_tag


### PR DESCRIPTION
…to dielectric volumes

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes #861 

### Did you add tests to cover your changes (yes/no)?
Yes

### Did you update the documentation accordingly (yes/no)?
Yes

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
Fixes the bug mentioned in #861 


### Details and comments
Changed the behavior of `if` statements in the method `assign_physical_groups` to include extra cases where it was failing.

