### PR TITLE
Fix for QGmshRenderer adding a ground_plane physical group even when …

### DIFF
--- a/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -915,28 +915,31 @@ class QGmshRenderer(QRenderer):
 
                 layer_name = layer_type + f'_(layer {layer})'
                 layer_tag = self.layers_dict[layer]
-                if layer_dim == 3:
-                    layer_sfs_tags = []
-                    for vol in layer_tag:
-                        layer_sfs_tags += list(
-                            gmsh.model.occ.getSurfaceLoops(vol)[1][0])
+                if len(layer_tag) > 0:
+                    if layer_dim == 3:
+                        layer_sfs_tags = []
+                        for vol in layer_tag:
+                            layer_sfs_tags += list(
+                                gmsh.model.occ.getSurfaceLoops(vol)[1][0])
 
-                    if layer_type != "ground_plane" or (
-                            layer_type == "ground_plane" and
-                            not ignore_metal_volume):
-                        ph_vol_tag = gmsh.model.addPhysicalGroup(
-                            dim=layer_dim, tags=layer_tag, name=layer_name)
-                        self.physical_groups[layer][layer_name] = ph_vol_tag
+                        if layer_type != "ground_plane" or (
+                                layer_type == "ground_plane" and
+                                not ignore_metal_volume):
+                            ph_vol_tag = gmsh.model.addPhysicalGroup(
+                                dim=layer_dim, tags=layer_tag, name=layer_name)
+                            self.physical_groups[layer][layer_name] = ph_vol_tag
 
-                    ph_sfs_tag = gmsh.model.addPhysicalGroup(
-                        dim=2, tags=layer_sfs_tags, name=f"{layer_name}_sfs")
-                    self.physical_groups[layer][
-                        f"{layer_name}_sfs"] = ph_sfs_tag
-                else:
-                    ph_tag = gmsh.model.addPhysicalGroup(dim=layer_dim,
-                                                         tags=layer_tag,
-                                                         name=layer_name)
-                    self.physical_groups[layer][layer_name] = ph_tag
+                        ph_sfs_tag = gmsh.model.addPhysicalGroup(
+                            dim=2,
+                            tags=layer_sfs_tags,
+                            name=f"{layer_name}_sfs")
+                        self.physical_groups[layer][
+                            f"{layer_name}_sfs"] = ph_sfs_tag
+                    else:
+                        ph_tag = gmsh.model.addPhysicalGroup(dim=layer_dim,
+                                                             tags=layer_tag,
+                                                             name=layer_name)
+                        self.physical_groups[layer][layer_name] = ph_tag
 
         if draw_sample_holder:
             # Make physical groups for vacuum box (volume)


### PR DESCRIPTION
…it is not in the model.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Closes #872 
Issue found by @diemilio and requires a minor change to fix it by adding a check for the ground plane layer if the `layers_dict` is empty or not.

### Did you add tests to cover your changes (yes/no)?
No

### Did you update the documentation accordingly (yes/no)?
Yes

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
This solves the issue that was caused due to missing a condition to check if the layers having ground plane actually exist in the model or not.


### Details and comments
Branch can be deleted after merging.

