### PR TITLE
Replace qt5-default dependency for Ubuntu 22.04

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -U virtualenv setuptools wheel tox
           sudo apt update
-          sudo apt-get install graphviz pandoc qt5-default
+          sudo apt-get install graphviz pandoc qtbase5-dev qt5-qmake
       - name: Build and publish
         env:
           encrypted_rclone_key: ${{ secrets.encrypted_rclone_key }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           python -m pip install -U tox
           sudo apt update
-          sudo apt install -y graphviz pandoc qt5-default
+          sudo apt install -y graphviz pandoc qtbase5-dev qt5-qmake
       - name: Build Docs
         run: tox -edocs
       - uses: actions/upload-artifact@v2
@@ -173,7 +173,7 @@ jobs:
 #          set -e
 #          python -m pip install --upgrade pip
 #          python -m pip install -U tox
-#          sudo apt install -y graphviz pandoc qt5-default
+#          sudo apt install -y graphviz pandoc qtbase5-dev qt5-qmake
 #          pip check
 #        shell: bash
 #      - name: Run Tutorials

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     # Name the Job
     name: tests-python${{ matrix.python-version }}-ubuntu-latest
     # Set the type of machine to run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # Set matrix for runs-on
     strategy:
       matrix:
@@ -29,11 +29,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ubuntu-20.04-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','requirements.txt') }}
+          key: ubuntu-latest-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','requirements.txt') }}
           restore-keys: |
-            ubuntu-20.04-${{ matrix.python-version }}-pip-tests-
-            ubuntu-20.04-${{ matrix.python-version }}-pip-
-            ubuntu-20.04-${{ matrix.python-version }}
+            ubuntu-latest-${{ matrix.python-version }}-pip-tests-
+            ubuntu-latest-${{ matrix.python-version }}-pip-
+            ubuntu-latest-${{ matrix.python-version }}
       - name: Install Deps
         run: |
           python -m pip install -U tox setuptools virtualenv wheel
@@ -99,7 +99,7 @@ jobs:
   #        shell: bash -l {0}
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.9
@@ -121,7 +121,7 @@ jobs:
         run: tox -elint
   docs:
     name: docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -152,7 +152,7 @@ jobs:
           path: docs/_build/html
 #  tutorials:
 #    name: tutorials
-#    runs-on: ubuntu-20.04
+#    runs-on: ubuntu-latest
 #    steps:
 #      - uses: actions/checkout@v3
 #      - name: Set up Python 3.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   wheel-build:
     name: Build and Publish Release Artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
N/A
### Did you add tests to cover your changes (yes/no)?
N/A
### Did you update the documentation accordingly (yes/no)?
N/A
### Did you read the CONTRIBUTING document (yes/no)?
Yes
### Summary
This replaces the qt5-default package with qtbase5-dev and  qt5-qmake for installation on Ubuntu 22.04.

### Details and comments
N/A

