### PR TITLE
Fix saving and loading of QDesign

### DIFF
--- a/qiskit_metal/designs/interface_components.py
+++ b/qiskit_metal/designs/interface_components.py
@@ -221,8 +221,11 @@ class Components:
     #     pass
     #     #self.__setitem__(name, value)
 
-    def __getstate__(self): return self.__dict__
-    def __setstate__(self, d): self.__dict__.update(d)
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
 
     def __contains__(self, item: str) -> int:
         """Look for item in design._components in the value.

--- a/qiskit_metal/designs/interface_components.py
+++ b/qiskit_metal/designs/interface_components.py
@@ -221,6 +221,8 @@ class Components:
     #     pass
     #     #self.__setitem__(name, value)
 
+    def __getstate__(self): return self.__dict__
+
     def __contains__(self, item: str) -> int:
         """Look for item in design._components in the value.
 

--- a/qiskit_metal/designs/interface_components.py
+++ b/qiskit_metal/designs/interface_components.py
@@ -222,6 +222,7 @@ class Components:
     #     #self.__setitem__(name, value)
 
     def __getstate__(self): return self.__dict__
+    def __setstate__(self, d): self.__dict__.update(d)
 
     def __contains__(self, item: str) -> int:
         """Look for item in design._components in the value.

--- a/qiskit_metal/tests/test_toolbox_metal.py
+++ b/qiskit_metal/tests/test_toolbox_metal.py
@@ -878,9 +878,10 @@ class TestToolboxMetal(unittest.TestCase, AssertionsMixin):
         #Save design to temporary file first
         self.test_saving_of_metal_design()
 
-        multiplanar_design = MultiPlanar(metadata={},
-                                         overwrite_enabled=True)
-        self.assertIsInstance(multiplanar_design.load_design(self.temp_file_name), MultiPlanar)
+        multiplanar_design = MultiPlanar(metadata={}, overwrite_enabled=True)
+        self.assertIsInstance(
+            multiplanar_design.load_design(self.temp_file_name), MultiPlanar)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Fixes #910. 

This is my suggested solution. Please kindly advise if there are other side effects that I have not considered or aware of. 🙂 

### Did you add tests to cover your changes (yes/no)?

Yes. 

On another note, other test cases are passing in my local at least. However, I would appreciate if there is feedback on the possible other side-effects from the changes I am proposing.

### Did you update the documentation accordingly (yes/no)?

No.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Currently, when saving a QDesign using the [save_design](https://qiskit.org/documentation/metal/stubs/qiskit_metal.designs.QDesign.save_design.html#qiskit_metal.designs.QDesign.save_design) method, throws an error saying `ERROR WHILE SAVING: 'NoneType' object is not callable`.

When the save_design error is fixed using suggestion solution (1), then another error appear when [load_design](https://qiskit.org/documentation/metal/stubs/qiskit_metal.designs.QDesign.load_design.html#qiskit_metal.designs.QDesign.load_design). The error is `RecursionError: maximum recursion depth exceeded`.

The proposed changes in this PR is to fix the issues mentioned above.

### Details and comments


