### PR TITLE
Display option name and option value of failed runs in the Sweeper class' run_sweep method

### DIFF
--- a/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
+++ b/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
@@ -164,9 +164,8 @@ class Sweeper():
                 template = "An exception of type {0} occurred. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
                 self.design.logger.warning(
-                    f'For class {self.parent.__class__.__name__}, ',
-                    f'option_name={".".join(option_path)}, key={item}, ',
-                    f'run() did not execute as expected: {message}')
+                    f'For class {self.parent.__class__.__name__}, option_name={".".join(option_path)}, key={item}, run() did not execute as expected: {message}'
+                )
 
             self.populate_all_sweep(all_sweep, item, args[1])
 

--- a/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
+++ b/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
@@ -164,7 +164,7 @@ class Sweeper():
                 template = "An exception of type {0} occurred. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
                 self.design.logger.warning(
-                    f'For class {self.parent.__class__.__name__}, run() did not execute as expected: {message}'
+                    f'For class {self.parent.__class__.__name__}, option_name={".".join(option_path)}, key={item}, run() did not execute as expected: {message}'
                 )
 
             self.populate_all_sweep(all_sweep, item, args[1])

--- a/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
+++ b/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
@@ -164,8 +164,9 @@ class Sweeper():
                 template = "An exception of type {0} occurred. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
                 self.design.logger.warning(
-                    f'For class {self.parent.__class__.__name__}, option_name={".".join(option_path)}, key={item}, run() did not execute as expected: {message}'
-                )
+                    f'For class {self.parent.__class__.__name__}, ',
+                    f'option_name={".".join(option_path)}, key={item}, ',
+                    f'run() did not execute as expected: {message}')
 
             self.populate_all_sweep(all_sweep, item, args[1])
 

--- a/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
+++ b/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
@@ -164,8 +164,9 @@ class Sweeper():
                 template = "An exception of type {0} occurred. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
                 self.design.logger.warning(
-                    f'For class {self.parent.__class__.__name__}, option_name={".".join(option_path)}, key={item}, run() did not execute as expected: {message}'
-                )
+                    f'For class {self.parent.__class__.__name__}, '
+                    f'option_name={".".join(option_path)}, key={item}, '
+                    f'run() did not execute as expected: {message}')
 
             self.populate_all_sweep(all_sweep, item, args[1])
 


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Fixes #907. There was a previous PR on this issue at PR [909](https://github.com/Qiskit/qiskit-metal/pull/909) which was merged to main branch and reverted at PR [912](https://github.com/Qiskit/qiskit-metal/pull/912) because the solution merged was not working. This PR fixes the issue in PR [909](https://github.com/Qiskit/qiskit-metal/pull/909).

### Did you add tests to cover your changes (yes/no)?

No. I'm not sure how to add test cases for this particular case.

### Did you update the documentation accordingly (yes/no)?

No.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Currently, when a run fails during the execution of Sweeper class' run_sweep method, the warning message, does not tell which option name or option value that failed.

It will be useful to add which option name + option value (key) combination thatdidn't execute properly for reference in case the user wantst to run the sweeperagain for the failed option values

This commit adds the option name and option value that failed to the warning message.

### Details and comments

