### PR TITLE
Fix for #63 Add QFilterProxy to the elements table

### DIFF
--- a/qiskit_metal/_gui/main_window.py
+++ b/qiskit_metal/_gui/main_window.py
@@ -560,15 +560,39 @@ class MetalGUI(QMainWindowBaseHandler):
         """Create main Window Elements Widget."""
         self.elements_win = ElementsWindow(self, self.main_window)
 
+        # Component filter
         self.ui.tabQGeometry.sort_model = QSortFilterProxyModel()
         self.ui.tabQGeometry.sort_model.setSourceModel(self.elements_win.model)
+        self.ui.tabQGeometry.sort_model.setFilterKeyColumn(1)
 
         self.elements_win.ui.tableElements.setModel(
             self.ui.tabQGeometry.sort_model)
         self.elements_win.ui.tableElements.setSortingEnabled(True)
 
+        # Add a text changed event to the QGeometry/Component/Layer text boxes
+        self.elements_win.ui.lineEdit.textChanged.connect(
+            self.elements_lineEdit_onChanged)
+        self.elements_win.ui.lineEdit_2.textChanged.connect(
+            self.elements_lineEdit_2_onChanged)
+
         # Add to the tabbed main view
         self.ui.tabQGeometry.layout().addWidget(self.elements_win)
+
+    def elements_lineEdit_onChanged(self, text):
+        """ Text changed event for QGeometry/Component text box
+        Args:
+            text: Text typed in the filter box.
+        """
+        self.ui.tabQGeometry.sort_model.setFilterKeyColumn(1)
+        self.ui.tabQGeometry.sort_model.setFilterWildcard(text)
+
+    def elements_lineEdit_2_onChanged(self, text):
+        """ Text changed event for QGeometry/Layer text box
+        Args:
+            text: Text typed in the filter box.
+        """
+        self.ui.tabQGeometry.sort_model.setFilterKeyColumn(3)
+        self.ui.tabQGeometry.sort_model.setFilterWildcard(text)
 
     def _setup_net_list_widget(self):
         """Create main Window Elements Widget."""


### PR DESCRIPTION
Fix for https://github.com/Qiskit/qiskit-metal/issues/63

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
https://github.com/Qiskit/qiskit-metal/issues/63

### Did you add tests to cover your changes (yes/no)?
No. UI changes.
### Did you update the documentation accordingly (yes/no)?
No. UI changes.
### Did you read the CONTRIBUTING document (yes/no)?
yes
### Summary
Fix for https://github.com/Qiskit/qiskit-metal/issues/63
You can filter geometries by Component name and/or layer

![image](https://github.com/Qiskit/qiskit-metal/assets/38670127/e0d6be71-782d-492d-9f08-abecc2f6a7fd)


### Details and comments


