### PR TITLE
Fix: force Python 3.10 in environment.yml to avoid PySide2 incompatibility

### DIFF
--- a/README_developers.md
+++ b/README_developers.md
@@ -38,9 +38,13 @@ Once you are in the folder that contains the `environemnt.yml` file, execute the
 ```sh
 conda env create -n <env_name> environment.yml
 conda activate <env_name>
+pip install pyside2==5.15.2.1
+pip install gmsh==4.11.1
+pip install pyepr-quantum==0.8.5.7
+pip install pyaedt==0.6.46
 python -m pip install --no-deps -e .
 ```
-Note the use of `--no-deps`. Indeed the `environment.yml` already instructs conda to install all the necessary package dependencies. We therefore prevent `setup.py` from overwriting them with the pip-equivalent packages, which might not be compatible with conda.
+Note the use of `--no-deps` in the final step. Indeed the `environment.yml` already instructs conda to install most necessary package dependencies. However, some packages (pyside2, gmsh, pyepr-quantum, and pyaedt) need to be installed manually via pip after the conda environment setup to avoid version conflicts. We therefore prevent `setup.py` from overwriting them with potentially incompatible packages.
 
 This creates a new environment with name `<env_name>` with all the necessary library dependencies.
 Then it activates the new environment.
@@ -54,6 +58,10 @@ If convenient, you can instead try to install directly in an existing conda envi
 ```
 conda env update -n <env_name_exist> environment.yml
 conda activate <env_name_exist>
+pip install pyside2==5.15.2.1
+pip install gmsh==4.11.1
+pip install pyepr-quantum==0.8.5.7
+pip install pyaedt==0.6.46
 python -m pip install --no-deps -e .
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: qiskit-metal
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python=3.10
   - addict==2.4.0
   - descartes==1.1.0
   - gdspy==1.6.12
@@ -12,9 +12,7 @@ dependencies:
   - numpy==1.24.2
   - pandas==1.5.3
   - pint==0.20.1
-  - pyepr-quantum==0.8.5.7
   - pygments==2.14.0
-  - pyside2==5.15.8
   - qdarkstyle==3.1
   - qutip==4.7.1
   - scipy==1.10.0
@@ -24,6 +22,3 @@ dependencies:
   - pyyaml==6.0
   - pip==23.0
   - cython<3.0.0
-  - pip:
-      - pyaedt==0.6.46
-      - gmsh==4.11.1


### PR DESCRIPTION
Previously, creating the conda environment from `environment.yml` would install Python ≥ 3.11, but `PySide2==5.15.2.1` does not exist for Python ≥ 3.11.
This caused installation failures with messages like:

```
Ignored … Requires-Python >=3.7,<3.11
```

which indicate that compatible wheels (e.g. NumPy 1.21.x and PySide2) only work up to Python 3.10.

To fix this, Python is now explicitly set to 3.10 in `environment.yml`. This ensures compatibility and allows successful installation of Qiskit Metal.

**Changes:**

* Set Python version to 3.10 in `environment.yml`
* Remove problematic pip dependencies from `environment.yml`
* Add clear instructions for manual pip installation in `README_developers.md`
* Simplify pip commands to use standard syntax

**What are the issues this pull addresses (issue numbers / links)?**
Fixes installation conflicts caused by incompatible Python version and pip dependencies in `environment.yml` that prevented a successful environment setup.

### Did you add tests to cover your changes (yes/no)?

No - these are installation/documentation changes. Existing unit tests were run and pass with the new installation method.

### Did you update the documentation accordingly (yes/no)?

Yes - Updated README_developers.md with clear step-by-step installation instructions including manual pip installation steps.

### Did you read the CONTRIBUTING document (yes/no)?

Yes

### Summary

The current environment.yml file causes version conflicts when installing pip dependencies (pyside2, gmsh, pyepr-quantum, pyaedt), making it difficult for developers to set up their environment successfully.

This PR resolves the issue by:
1. Removing problematic pip dependencies from environment.yml
2. Adding manual pip installation steps in README_developers.md
3. Specifying Python 3.10 for better compatibility
4. Providing clear documentation for both new and existing conda environments

### Details and comments

**Problem**: The environment.yml file included pip dependencies that caused conflicts during conda environment creation, particularly with packages like pyside2, gmsh, pyepr-quantum, and pyaedt.

**Solution**: 
- **environment.yml**: Removed pip dependencies and specified Python 3.10
- **README_developers.md**: Added comprehensive manual installation instructions for both Option 1 (new environment) and Option 2 (existing environment)

**New Installation Process**:
1. Create conda environment: `conda env create -n <env_name> environment.yml`
2. Activate environment: `conda activate <env_name>`
3. Install pip dependencies manually:
   - `pip install pyside2==5.15.2.1`
   - `pip install gmsh==4.11.1`
   - `pip install pyepr-quantum==0.8.5.7`
   - `pip install pyaedt==0.6.46`
4. Install qiskit-metal: `python -m pip install --no-deps -e .`

This approach eliminates version conflicts and provides a reliable installation path for developers.