### PR TITLE
Fix TransmonCross claw `port_line` width bug

### DIFF
--- a/qiskit_metal/qlibrary/qubits/transmon_cross.py
+++ b/qiskit_metal/qlibrary/qubits/transmon_cross.py
@@ -204,7 +204,7 @@ class TransmonCross(BaseQubit):  # pylint: disable=invalid-name
         # extract from the connector later, but since allowing different connector types,
         # this seems more straightforward.
         port_line = draw.LineString([(-c_c_l - c_w, -c_c_w / 2),
-                                     (-c_c_l - c_w, c_w / 2)])
+                                     (-c_c_l - c_w, c_c_w / 2)])
 
         claw_rotate = 0
         if con_loc > 135:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Resolve #1024, Resolve #1016 
### Did you add tests to cover your changes (yes/no)?
No, since it is simple bug fix

### Did you update the documentation accordingly (yes/no)?
No

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
Fix the bug for misaligns geometry between `TransmonCrossFl` and `RouteMeander`


### Details and comments
This PR fixes the `TransmonCross` claw pin definition.
It appeared to work only at `claw_width = 10` because the defaults have `claw_width `and `claw_cpw_width` are 10 um, so the wrong variable happened to give the correct coordinate.
**Fixed geometry**:
<img width="314" height="429" alt="image" src="https://github.com/user-attachments/assets/0fca6b21-3b29-4a77-8c70-5866af14db77" />
